### PR TITLE
fix(routes): graphiql redirection if a prefix have been set

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ __fastify-gql__ supports the following options:
   executed before being jit'ed.
 * `routes`: boolean. Serves the Default: `true`. A graphql endpoint is
   exposed at `/graphql`.
-* `prefix`: String. Change the route prefix of graphql endpoint if enabled.
+* `prefix`: String. Change the route prefix of the graphql endpoint if enabled.
 
 ### HTTP endpoints
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ __fastify-gql__ supports the following options:
   executed before being jit'ed.
 * `routes`: boolean. Serves the Default: `true`. A graphql endpoint is
   exposed at `/graphql`.
+* `prefix`: String. Change the route prefix of graphql endpoint if enabled.
 
 ### HTTP endpoints
 

--- a/index.js
+++ b/index.js
@@ -75,7 +75,8 @@ module.exports = fp(async function (app, opts) {
 
   if (opts.routes !== false) {
     app.register(routes, {
-      graphiql: opts.graphiql
+      graphiql: opts.graphiql,
+      prefix: opts.prefix
     })
   }
 

--- a/routes.js
+++ b/routes.js
@@ -107,7 +107,7 @@ module.exports = async function (app, opts) {
     })
 
     app.get('/graphiql', (req, reply) => {
-      reply.redirect('/graphiql.html')
+      reply.redirect(`${app.basePath}/graphiql.html`)
     })
   }
 }

--- a/test/routes.js
+++ b/test/routes.js
@@ -572,17 +572,33 @@ test('GET graphiql endpoint', async (t) => {
 
 test('GET graphiql endpoint with prefix', async (t) => {
   const app = Fastify()
+  app.register(GQL, {
+    graphiql: true,
+    prefix: '/test-prefix'
+  })
+
+  const res = await app.inject({
+    method: 'GET',
+    url: '/test-prefix/graphiql'
+  })
+
+  t.strictEqual(res.statusCode, 302)
+  t.strictEqual(res.headers.location, '/test-prefix/graphiql.html')
+})
+
+test('GET graphiql endpoint with prefixed wrapper', async (t) => {
+  const app = Fastify()
   app.register(async function (app, opts) {
     app.register(GQL, {
       graphiql: true
     })
-  }, { prefix: '/test' })
+  }, { prefix: '/test-wrapper-prefix' })
 
   const res = await app.inject({
     method: 'GET',
-    url: '/test/graphiql'
+    url: '/test-wrapper-prefix/graphiql'
   })
 
   t.strictEqual(res.statusCode, 302)
-  t.strictEqual(res.headers.location, '/test/graphiql.html')
+  t.strictEqual(res.headers.location, '/test-wrapper-prefix/graphiql.html')
 })

--- a/test/routes.js
+++ b/test/routes.js
@@ -602,3 +602,31 @@ test('GET graphiql endpoint with prefixed wrapper', async (t) => {
   t.strictEqual(res.statusCode, 302)
   t.strictEqual(res.headers.location, '/test-wrapper-prefix/graphiql.html')
 })
+
+test('GET graphql endpoint with prefix', async (t) => {
+  const app = Fastify()
+  app.register(GQL, {
+    prefix: '/test-prefix'
+  })
+
+  const res = await app.inject({
+    method: 'GET',
+    url: '/test-prefix/graphql'
+  })
+
+  t.strictEqual(res.statusCode, 400)
+})
+
+test('GET graphql endpoint with prefixed wrapper', async (t) => {
+  const app = Fastify()
+  app.register(async function (app, opts) {
+    app.register(GQL, {})
+  }, { prefix: '/test-wrapper-prefix' })
+
+  const res = await app.inject({
+    method: 'GET',
+    url: '/test-wrapper-prefix/graphql'
+  })
+
+  t.strictEqual(res.statusCode, 400)
+})

--- a/test/routes.js
+++ b/test/routes.js
@@ -555,3 +555,35 @@ test('error if there are functions defined in the root object', async (t) => {
     t.is(err.message, 'jit is not possible if there are root functions')
   }
 })
+
+test('GET graphiql endpoint', async (t) => {
+  const app = Fastify()
+  app.register(GQL, {
+    graphiql: true,
+    prefix: '/test'
+  })
+
+  const res = await app.inject({
+    method: 'GET',
+    url: '/graphiql'
+  })
+  t.strictEqual(res.statusCode, 302)
+  t.strictEqual(res.headers.location, '/graphiql.html')
+})
+
+test('GET graphiql endpoint with prefix', async (t) => {
+  const app = Fastify()
+  app.register(async function (app, opts) {
+    app.register(GQL, {
+      graphiql: true
+    })
+  }, { prefix: '/test' })
+
+  const res = await app.inject({
+    method: 'GET',
+    url: '/test/graphiql'
+  })
+
+  t.strictEqual(res.statusCode, 302)
+  t.strictEqual(res.headers.location, '/test/graphiql.html')
+})

--- a/test/routes.js
+++ b/test/routes.js
@@ -559,8 +559,7 @@ test('error if there are functions defined in the root object', async (t) => {
 test('GET graphiql endpoint', async (t) => {
   const app = Fastify()
   app.register(GQL, {
-    graphiql: true,
-    prefix: '/test'
+    graphiql: true
   })
 
   const res = await app.inject({

--- a/test/routes.js
+++ b/test/routes.js
@@ -605,28 +605,53 @@ test('GET graphiql endpoint with prefixed wrapper', async (t) => {
 
 test('GET graphql endpoint with prefix', async (t) => {
   const app = Fastify()
+  const schema = `
+    type Query {
+      add(x: Int, y: Int): Int
+    }
+  `
+  const resolvers = {
+    add: async ({ x, y }) => x + y
+  }
+
   app.register(GQL, {
+    schema,
+    resolvers,
     prefix: '/test-prefix'
   })
 
   const res = await app.inject({
     method: 'GET',
-    url: '/test-prefix/graphql'
+    url: '/test-prefix/graphql?query={add(x:2,y:2)}'
   })
 
-  t.strictEqual(res.statusCode, 400)
+  t.strictEqual(res.statusCode, 200)
 })
 
 test('GET graphql endpoint with prefixed wrapper', async (t) => {
   const app = Fastify()
+
   app.register(async function (app, opts) {
-    app.register(GQL, {})
+    const schema = `
+    type Query {
+      add(x: Int, y: Int): Int
+    }
+    `
+
+    const resolvers = {
+      add: async ({ x, y }) => x + y
+    }
+
+    app.register(GQL, {
+      schema,
+      resolvers
+    })
   }, { prefix: '/test-wrapper-prefix' })
 
   const res = await app.inject({
     method: 'GET',
-    url: '/test-wrapper-prefix/graphql'
+    url: '/test-wrapper-prefix/graphql?query={add(x:2,y:2)}'
   })
 
-  t.strictEqual(res.statusCode, 400)
+  t.strictEqual(res.statusCode, 200)
 })


### PR DESCRIPTION
The redirection is incorrect if the plugin is registered with a prefix. 
This PR fixes the issue ;)