### PR TITLE
Plugin name definition

### DIFF
--- a/index.js
+++ b/index.js
@@ -204,4 +204,6 @@ module.exports = fp(async function (app, opts) {
 
     return execution
   }
+}, {
+  name: 'fastify-gql'
 })

--- a/test/plugin-definition.js
+++ b/test/plugin-definition.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const { test } = require('tap')
+const fp = require('fastify-plugin')
+const Fastify = require('fastify')
+const GQL = require('..')
+
+test('plugin name definition', async (t) => {
+  const app = Fastify()
+  app.register(GQL)
+  app.register(fp(async (app, opts) => {}, {
+    dependencies: ['fastify-gql']
+  }))
+
+  t.resolves(app.ready())
+})


### PR DESCRIPTION
There is no plugin definition which makes dependencies resolution not working if a plugin depends on `fastify-gql`