### PR TITLE
Handle errors according to graphql spec and allow custom error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ __fastify-gql__ supports the following options:
   exposed at `/graphql`.
 * `prefix`: String. Change the route prefix of the graphql endpoint if enabled.
 * `defineMutation`: Boolean. Add the empty Mutation definition if schema is not defined (Default: `false`).
-* `errorHandler`: Function. Change the default error handler (Default: `false`). _Note: If a custom error handler is defined, it should return the standardized response format according to [GraphQL spec](https://graphql.org/learn/serving-over-http/#response)._
+* `errorHandler`: Function. Change the default error handler (Default: `true`). _Note: If a custom error handler is defined, it should return the standardized response format according to [GraphQL spec](https://graphql.org/learn/serving-over-http/#response)._
 
 ### HTTP endpoints
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ __fastify-gql__ supports the following options:
   exposed at `/graphql`.
 * `prefix`: String. Change the route prefix of the graphql endpoint if enabled.
 * `defineMutation`: Boolean. Add the empty Mutation definition if schema is not defined (Default: `false`).
-* `errorHandler`: Function. Change the default error handler.
+* `errorHandler`: Function. Change the default error handler (Default: `false`). _Note: If a custom error handler is defined, it should return the standardized response format according to [GraphQL spec](https://graphql.org/learn/serving-over-http/#response)._
 
 ### HTTP endpoints
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ __fastify-gql__ supports the following options:
   exposed at `/graphql`.
 * `prefix`: String. Change the route prefix of the graphql endpoint if enabled.
 * `defineMutation`: Boolean. Add the empty Mutation definition if schema is not defined (Default: `false`).
-* `errorHandler`: Function. Change the default error handler (Default: `true`). _Note: If a custom error handler is defined, it should return the standardized response format according to [GraphQL spec](https://graphql.org/learn/serving-over-http/#response)._
+* `errorHandler`: `Function`  or `boolean`. Change the default error handler (Default: `true`). _Note: If a custom error handler is defined, it should return the standardized response format according to [GraphQL spec](https://graphql.org/learn/serving-over-http/#response)._
 
 ### HTTP endpoints
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ __fastify-gql__ supports the following options:
   exposed at `/graphql`.
 * `prefix`: String. Change the route prefix of the graphql endpoint if enabled.
 * `defineMutation`: Boolean. Add the empty Mutation definition if schema is not defined (Default: `false`).
+* `errorHandler`: Function. Change the default error handler.
 
 ### HTTP endpoints
 

--- a/index.js
+++ b/index.js
@@ -178,7 +178,7 @@ module.exports = fp(async function (app, opts) {
       const operationAST = getOperationAST(document, operationName)
       if (operationAST.operation !== 'query') {
         const err = new MethodNotAllowed()
-        err.errors = { errors: ['Operation cannot be perfomed via a GET request'] }
+        err.errors = [ new Error('Operation cannot be perfomed via a GET request') ]
         throw err
       }
     }

--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ module.exports = fp(async function (app, opts) {
 
   if (opts.routes !== false) {
     app.register(routes, {
+      errorHandler: opts.errorHandler,
       graphiql: opts.graphiql,
       prefix: opts.prefix
     })

--- a/routes.js
+++ b/routes.js
@@ -67,7 +67,11 @@ function validationHandler (validationError) {
 }
 
 module.exports = async function (app, opts) {
-  app.setErrorHandler(opts.errorHandler || defaultErrorHandler)
+  if (typeof opts.errorHandler === 'function') {
+    app.setErrorHandler(opts.errorHandler)
+  } else if (opts.errorHandler === true || opts.errorHandler === undefined) {
+    app.setErrorHandler(defaultErrorHandler)
+  }
 
   app.get('/graphql', {
     schema: {

--- a/routes.js
+++ b/routes.js
@@ -58,6 +58,14 @@ async function defaultErrorHandler (err, request, reply) {
   }
 }
 
+function validationHandler (validationError) {
+  if (validationError) {
+    const err = new BadRequest()
+    err.errors = [validationError]
+    throw err
+  }
+}
+
 module.exports = async function (app, opts) {
   app.setErrorHandler(opts.errorHandler || defaultErrorHandler)
 
@@ -78,8 +86,11 @@ module.exports = async function (app, opts) {
         }
       },
       response: responseSchema
-    }
+    },
+    attachValidation: true
   }, function (request, reply) {
+    validationHandler(request.validationError)
+
     let {
       query,
       variables,
@@ -118,8 +129,11 @@ module.exports = async function (app, opts) {
         }
       },
       response: responseSchema
-    }
-  }, function (request, reply) {
+    },
+    attachValidation: true
+  }, async function (request, reply) {
+    validationHandler(request.validationError)
+
     const {
       query,
       variables,

--- a/routes.js
+++ b/routes.js
@@ -17,21 +17,23 @@ const responseSchema = {
   }
 }
 
-module.exports = async function (app, opts) {
-  app.setErrorHandler(async function (err, request, reply) {
-    if (!err.statusCode) {
-      throw err
-    }
+async function defaultErrorHandler (err, request, reply) {
+  if (!err.statusCode) {
+    throw err
+  }
 
-    reply.code(err.statusCode)
-    if (err.errors) {
-      return { errors: err.errors }
-    } else {
-      return {
-        message: err.message
-      }
+  reply.code(err.statusCode)
+  if (err.errors) {
+    return { errors: err.errors }
+  } else {
+    return {
+      message: err.message
     }
-  })
+  }
+}
+
+module.exports = async function (app, opts) {
+  app.setErrorHandler(opts.errorHandler || defaultErrorHandler)
 
   app.get('/graphql', {
     schema: {

--- a/tap-snapshots/test-routes.js-TAP.test.js
+++ b/tap-snapshots/test-routes.js-TAP.test.js
@@ -61,10 +61,10 @@ exports[`test/routes.js TAP POST return 400 on error > undefined 1`] = `
 
 exports[`test/routes.js TAP mutation with GET errors > undefined 1`] = `
 {
-  "errors": {
-    "errors": [
-      "Operation cannot be perfomed via a GET request"
-    ]
-  }
+  "errors": [
+    {
+      "message": "Operation cannot be perfomed via a GET request"
+    }
+  ]
 }
 `

--- a/test/routes.js
+++ b/test/routes.js
@@ -665,7 +665,9 @@ test('Custom error handler', async (t) => {
   `
 
   const resolvers = {
-    add: async ({ x, y }) => x + y
+    add: async ({ x, y }) => {
+      throw new Error('dummy error')
+    }
   }
 
   function errorHandler (error, req, reply) {


### PR DESCRIPTION
This PR adds the errorHandler option to fastify-gql in order to allow custom error handling.
With test and documentation.