### PR TITLE
Uses the relative path to prevent error 404 when a prefix is used

### DIFF
--- a/static/graphiql.html
+++ b/static/graphiql.html
@@ -24,7 +24,7 @@
   <div id="main"></div>
   <script>
     async function fetcher (params) {
-      const res = await fetch('/graphql', {
+      const res = await fetch('graphql', {
         method: 'post',
         headers: {
           'Accept': 'application/json',


### PR DESCRIPTION
The fastify prefix option doesn't affect the graphiql's static page when consuming graphql endpoint.