### PR TITLE
docs: typo in require makeExecutableSchema  example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ See test.js for more examples, docs are coming.
 
 const Fastify = require('fastify')
 const GQL = require('fastify-gql')
-const { makeExecutableSchema } = require('graphq-tools')
+const { makeExecutableSchema } = require('graphql-tools')
 
 const app = Fastify()
 


### PR DESCRIPTION
Just fixed a typo in README, thank you