### PR TITLE
Fix TypeError: this.queue.close is not a function

### DIFF
--- a/lib/subscriber.js
+++ b/lib/subscriber.js
@@ -61,7 +61,9 @@ class SubscriptionContext {
   }
 
   close () {
-    this.queue.close()
+    if (typeof this.queue.close === 'function') {
+      this.queue.close()
+    }
     this.queue.destroy()
   }
 }

--- a/lib/subscriber.js
+++ b/lib/subscriber.js
@@ -61,6 +61,8 @@ class SubscriptionContext {
   }
 
   close () {
+    // In rare cases when `subscribe()` not called (e.g. some network error)
+    // `close` will be `undefined`.
     /* istanbul ignore else */
     if (typeof this.queue.close === 'function') {
       this.queue.close()

--- a/lib/subscriber.js
+++ b/lib/subscriber.js
@@ -61,6 +61,7 @@ class SubscriptionContext {
   }
 
   close () {
+    /* istanbul ignore else */
     if (typeof this.queue.close === 'function') {
       this.queue.close()
     }

--- a/lib/subscriber.js
+++ b/lib/subscriber.js
@@ -63,7 +63,6 @@ class SubscriptionContext {
   close () {
     // In rare cases when `subscribe()` not called (e.g. some network error)
     // `close` will be `undefined`.
-    /* istanbul ignore else */
     if (typeof this.queue.close === 'function') {
       this.queue.close()
     }

--- a/test/subscriber.js
+++ b/test/subscriber.js
@@ -19,6 +19,16 @@ test('subscriber published an event', async (t) => {
   })
 })
 
+test('subscription context not throw error on close', t => {
+  t.plan(1)
+  const pubsub = new PubSub(mq())
+
+  const sc = new SubscriptionContext({ pubsub })
+
+  sc.close()
+  t.pass()
+})
+
 test('subscription context publish event returns a promise', t => {
   t.plan(1)
   const pubsub = new PubSub(mq())


### PR DESCRIPTION
In some rare cases there's a possibility when `close` will be called before `subscribe` will happen. In this case that error could cause even app server crash. Also it prevents `this.queue.destroy()` to be called.

I don't know how to properly test this case, cause it's caused by some abnormal behaviour of client side. Tried some options with closing ws client right after establishing connection, sending some crappy staff into it - nothing caused this bug to appear.
Anyway it's present and needed to be fixed.