### PR TITLE
Feature: Add custom path into GQL constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ __fastify-gql__ supports the following options:
   executed before being jit'ed.
 * `routes`: boolean. Serves the Default: `true`. A graphql endpoint is
   exposed at `/graphql`.
+* `path`: string. Change default graphql `/graphql` route to another one.
 * `context`: `Function`. Result of function is passed to resolvers as a custom GraphQL context. The function receives the `request` and `reply` as parameters. It is only called when `routes` options is `true`
 * `prefix`: String. Change the route prefix of the graphql endpoint if enabled.
 * `defineMutation`: Boolean. Add the empty Mutation definition if schema is not defined (Default: `false`).

--- a/index.d.ts
+++ b/index.d.ts
@@ -89,6 +89,11 @@ declare namespace FastifyGQL {
      */
     routes?: boolean,
     /**
+     * An endpoint for graphql if routes is true
+     * @default '/graphql'
+     */
+    path?: string,
+    /**
      * Change the route prefix of the graphql endpoint if set
      */
     prefix?: string,

--- a/index.js
+++ b/index.js
@@ -91,6 +91,7 @@ module.exports = fp(async function (app, opts) {
       errorHandler: opts.errorHandler,
       ide: optsIde,
       prefix: opts.prefix,
+      path: opts.path,
       context: opts.context,
       schema,
       subscription: opts.subscription

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -89,8 +89,10 @@ module.exports = async function (app, opts) {
     subscriber = new PubSub(emitter)
   }
 
+  const { path: graphqlPath = '/graphql' } = opts
+
   const getOptions = {
-    url: '/graphql',
+    url: graphqlPath,
     method: 'GET',
     schema: {
       querystring: {
@@ -149,7 +151,7 @@ module.exports = async function (app, opts) {
     app.route(getOptions)
   }
 
-  app.post('/graphql', {
+  app.post(graphqlPath, {
     schema: {
       body: {
         type: 'object',

--- a/test/routes.js
+++ b/test/routes.js
@@ -41,6 +41,42 @@ test('POST route', async (t) => {
   })
 })
 
+test('custom route', async (t) => {
+  const app = Fastify()
+  const schema = `
+    type Query {
+      add(x: Int, y: Int): Int
+    }
+  `
+
+  const resolvers = {
+    add: async ({ x, y }) => x + y
+  }
+
+  app.register(GQL, {
+    schema,
+    resolvers,
+    path: '/custom'
+  })
+
+  const query = '{ add(x: 2, y: 2) }'
+
+  const res = await app.inject({
+    method: 'POST',
+    url: '/custom',
+    body: {
+      query
+    }
+  })
+
+  t.equal(res.statusCode, 200)
+  t.deepEqual(JSON.parse(res.body), {
+    data: {
+      add: 4
+    }
+  })
+})
+
 test('GET route', async (t) => {
   const app = Fastify()
   const schema = `


### PR DESCRIPTION
This PR tries to close #103 

I have not found a way of providing custom graphql endpoint to playground/graphiql.

@mcollina Could you help me with it?