### PR TITLE
fix: error handler setting undefined status code

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -54,8 +54,8 @@ const responseSchema = {
 async function defaultErrorHandler (err, request, reply) {
   if (err.data) {
     reply.code(200)
-  } else if (err.statusCode) {
-    reply.code(err.statusCode)
+  } else {
+    reply.code(err.statusCode || 500)
   }
 
   if (err.errors) {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -54,7 +54,7 @@ const responseSchema = {
 async function defaultErrorHandler (err, request, reply) {
   if (err.data) {
     reply.code(200)
-  } else {
+  } else if (err.statusCode) {
     reply.code(err.statusCode)
   }
 

--- a/tap-snapshots/test-routes.js-TAP.test.js
+++ b/tap-snapshots/test-routes.js-TAP.test.js
@@ -66,6 +66,17 @@ exports['test/routes.js TAP POST return 400 on error > must match snapshot 1'] =
 }
 `
 
+exports['test/routes.js TAP POST return 500 on error without statusCode > must match snapshot 1'] = `
+{
+  "errors": [
+    {
+      "message": "Interface field Event.Id expected but CustomEvent does not provide it."
+    }
+  ],
+  "data": null
+}
+`
+
 exports['test/routes.js TAP mutation with GET errors > must match snapshot 1'] = `
 {
   "errors": [

--- a/test/routes.js
+++ b/test/routes.js
@@ -433,6 +433,44 @@ test('POST return 400 on error', async (t) => {
   t.matchSnapshot(JSON.stringify(JSON.parse(res.body), null, 2))
 })
 
+test('POST return 500 on error without statusCode', async (t) => {
+  const app = Fastify()
+  const schema = `
+    interface Event {
+      Id: Int!
+    }
+    type CustomEvent implements Event {
+      # Id needs to be specified here
+      Name: String!
+    }
+    type Query {
+      listEvent: [Event]
+    }
+  `
+
+  const resolvers = {
+    listEvent: async () => []
+  }
+
+  app.register(GQL, {
+    schema,
+    resolvers
+  })
+
+  const query = '{ listEvent { id } }'
+
+  const res = await app.inject({
+    method: 'POST',
+    url: '/graphql',
+    body: {
+      query
+    }
+  })
+
+  t.equal(res.statusCode, 500) // Internal error
+  t.matchSnapshot(JSON.stringify(JSON.parse(res.body), null, 2))
+})
+
 test('mutation with POST', async (t) => {
   const app = Fastify()
   const schema = `


### PR DESCRIPTION
Only set error response status code when it is defined. Otherwise [response will be truncated.](https://github.com/fastify/fastify/issues/2078).