### PR TITLE
updates the way query depth is computed

### DIFF
--- a/lib/queryDepth.js
+++ b/lib/queryDepth.js
@@ -14,16 +14,14 @@ const { Kind } = require('graphql')
 function queryDepth (definitions, queryDepthLimit) {
   const queries = getQueriesAndMutations(definitions)
   const queryDepth = {}
+
   for (const name in queries) {
     queryDepth[name] = determineDepth(queries[name])
   }
   const errors = []
-
   if (typeof queryDepthLimit === 'number') {
     for (const query of Object.keys(queryDepth)) {
-      const totalDepth = Object.values(queryDepth[query]).reduce((acc, curr) => {
-        return acc + curr
-      })
+      const totalDepth = queryDepth[query]
       if (totalDepth > queryDepthLimit) {
         const queryDepthError = new Error(`${query} query exceeds the query depth limit of ${queryDepthLimit}`)
         errors.push(queryDepthError)
@@ -33,7 +31,15 @@ function queryDepth (definitions, queryDepthLimit) {
 
   return errors
 }
-
+function determineDepth (node, current = 0) {
+  let result = current
+  if (node.selectionSet) {
+    node.selectionSet.selections.forEach(selection => {
+      result = determineDepth(selection, current++)
+    })
+  }
+  return result
+}
 function getQueriesAndMutations (definitions) {
   return definitions.reduce((map, definition) => {
     if (definition.kind === Kind.OPERATION_DEFINITION) {
@@ -43,19 +49,20 @@ function getQueriesAndMutations (definitions) {
   }, {})
 }
 
-function determineDepth (node, totals = {}) {
-  if (node.selectionSet) {
-    const name = node.name ? node.name.value : 'unnamedNode'
-    if (totals[name]) {
-      totals[name] += 1
-    } else {
-      totals[name] = 1
-    }
-    node.selectionSet.selections.forEach(selection => {
-      determineDepth(selection, totals)
-    })
-  }
-  return totals
-}
+// function determineDepth (node, currentDepth = 0, totals = {}) {
+//   //console.log(node, totals);
+//   if (node.selectionSet) {
+//     const name = node.name ? node.name.value : 'unnamedNode'
+//     if (totals[name]) {
+//       totals[name] += 1
+//     } else {
+//       totals[name] = 1
+//     }
+//     node.selectionSet.selections.forEach(selection => {
+//       determineDepth(selection, currentDepth++, totals)
+//     })
+//   }
+//   return totals
+// }
 
 module.exports = queryDepth

--- a/lib/queryDepth.js
+++ b/lib/queryDepth.js
@@ -18,6 +18,7 @@ function queryDepth (definitions, queryDepthLimit) {
   for (const name in queries) {
     queryDepth[name] = determineDepth(queries[name])
   }
+
   const errors = []
   if (typeof queryDepthLimit === 'number') {
     for (const query of Object.keys(queryDepth)) {
@@ -34,9 +35,9 @@ function queryDepth (definitions, queryDepthLimit) {
 function determineDepth (node, current = 0) {
   let result = current
   if (node.selectionSet) {
-    node.selectionSet.selections.forEach(selection => {
+    for (const selection of node.selectionSet.selections) {
       result = determineDepth(selection, current++)
-    })
+    }
   }
   return result
 }
@@ -48,21 +49,5 @@ function getQueriesAndMutations (definitions) {
     return map
   }, {})
 }
-
-// function determineDepth (node, currentDepth = 0, totals = {}) {
-//   //console.log(node, totals);
-//   if (node.selectionSet) {
-//     const name = node.name ? node.name.value : 'unnamedNode'
-//     if (totals[name]) {
-//       totals[name] += 1
-//     } else {
-//       totals[name] = 1
-//     }
-//     node.selectionSet.selections.forEach(selection => {
-//       determineDepth(selection, currentDepth++, totals)
-//     })
-//   }
-//   return totals
-// }
 
 module.exports = queryDepth

--- a/test/query-depth.js
+++ b/test/query-depth.js
@@ -431,7 +431,6 @@ test('queryDepth - ensure query depth is correctly calculated', async (t) => {
       }
     })
   } catch (error) {
-    console.log(error)
     t.fail(error.message)
   }
 })

--- a/test/query-depth.js
+++ b/test/query-depth.js
@@ -264,7 +264,7 @@ test('queryDepth - ensure query depth is correctly calculated', async (t) => {
     id: ID
     name: String
     description: String
-    nutrition: Nutrition 
+    nutrition: Nutrition
     recipes: [Recipe]
     seasons: [Season]
   }
@@ -355,7 +355,7 @@ test('queryDepth - ensure query depth is correctly calculated', async (t) => {
   const query = `{
     flavors {
       id
-      name 
+      name
       nutrition {
         calories,
         description {
@@ -387,50 +387,46 @@ test('queryDepth - ensure query depth is correctly calculated', async (t) => {
   // needed so that graphql is defined
   await app.ready()
 
-  try {
-    const res = await app.graphql(query)
-    t.deepEqual(res, {
-      data: {
-        flavors: [
-          {
-            id: '1',
-            name: 'Strawberry',
-            nutrition: {
-              calories: 123,
-              description: {
-                body: 'lorem ipsum',
-                other: {
-                  body: 'another string'
-                }
+  const res = await app.graphql(query)
+  t.deepEqual(res, {
+    data: {
+      flavors: [
+        {
+          id: '1',
+          name: 'Strawberry',
+          nutrition: {
+            calories: 123,
+            description: {
+              body: 'lorem ipsum',
+              other: {
+                body: 'another string'
               }
+            }
+          },
+          recipes: [
+            {
+              name: 'Strawberry Cake',
+              ingredients: [
+                { name: 'milk' },
+                { name: 'sugar' },
+                { name: 'butter' }
+              ]
             },
-            recipes: [
-              {
-                name: 'Strawberry Cake',
-                ingredients: [
-                  { name: 'milk' },
-                  { name: 'sugar' },
-                  { name: 'butter' }
-                ]
-              },
-              {
-                name: 'Strawberry Ice Cream',
-                ingredients: [
-                  { name: 'milk' },
-                  { name: 'sugar' },
-                  { name: 'butter' }
-                ]
-              }
-            ],
-            seasons: [
-              { name: 'Spring' },
-              { name: 'Summer' }
-            ]
-          }
-        ]
-      }
-    })
-  } catch (error) {
-    t.fail(error.message)
-  }
+            {
+              name: 'Strawberry Ice Cream',
+              ingredients: [
+                { name: 'milk' },
+                { name: 'sugar' },
+                { name: 'butter' }
+              ]
+            }
+          ],
+          seasons: [
+            { name: 'Spring' },
+            { name: 'Summer' }
+          ]
+        }
+      ]
+    }
+  })
 })

--- a/test/query-depth.js
+++ b/test/query-depth.js
@@ -144,7 +144,7 @@ test('queryDepth - test total depth is within queryDepth parameter', async (t) =
   app.register(GQL, {
     schema,
     resolvers,
-    queryDepth: 6
+    queryDepth: 5
   })
 
   // needed so that graphql is defined
@@ -156,19 +156,20 @@ test('queryDepth - test total depth is within queryDepth parameter', async (t) =
 })
 
 test('queryDepth - test total depth is over queryDepth parameter', async (t) => {
+  t.plan(1)
   const app = Fastify()
 
   app.register(GQL, {
     schema,
     resolvers,
-    queryDepth: 5
+    queryDepth: 3
   })
 
   // needed so that graphql is defined
   await app.ready()
 
   const err = new BadRequest()
-  const queryDepthError = new Error('unnamedQuery query exceeds the query depth limit of 5')
+  const queryDepthError = new Error('unnamedQuery query exceeds the query depth limit of 3')
   err.errors = [queryDepthError]
 
   try {
@@ -231,4 +232,206 @@ test('queryDepth - definition.kind and definition.name change', async (t) => {
   const res = await app.graphql(localQuery)
 
   t.deepEqual(res, goodResponse)
+})
+
+test('queryDepth - ensure query depth is correctly calculated', async (t) => {
+  const schema = `
+  type Nutrition {
+      flavorId: ID
+      calories: Int
+      fat: Int
+      sodium: Int,
+      description: NutritionDescription
+    }
+
+  type NutritionDescription {
+    body: String
+    other: AnotherType
+  }
+  type AnotherType {
+    body: String
+  }
+
+  type Recipe {
+    name: String
+    ingredients: [Ingredient]
+  }
+
+  type Ingredient {
+    name: String,
+  }
+  type Flavor {
+    id: ID
+    name: String
+    description: String
+    nutrition: Nutrition 
+    recipes: [Recipe]
+    seasons: [Season]
+  }
+
+  type Season {
+    name: String
+  }
+  type Query {
+    flavors: [Flavor],
+    otherFlavors: [Flavor]
+  }
+`
+  const resolvers = {
+    Query: {
+      otherFlavors (params, { reply }) {
+        return [
+          {
+            id: 2,
+            name: 'Blueberry',
+            seasons: [
+              { name: 'Spring' },
+              { name: 'Fall' }
+            ]
+          },
+          {
+            id: 3,
+            name: 'Blackberry',
+            seasons: [
+              { name: 'Winter' }
+            ]
+          }
+        ]
+      },
+      flavors (params, { reply }) {
+        return [
+          {
+            id: 1,
+            name: 'Strawberry',
+            seasons: [
+              { name: 'Spring' },
+              { name: 'Summer' }
+            ]
+          }
+        ]
+      }
+    },
+    Flavor: {
+      nutrition (params) {
+        return {
+          flavorId: 1,
+          calories: 123,
+          sodium: 10,
+          fat: 1
+        }
+      },
+      recipes (params) {
+        return [
+          { name: 'Strawberry Cake' },
+          { name: 'Strawberry Ice Cream' }
+        ]
+      }
+    },
+    Recipe: {
+      ingredients (params) {
+        return [
+          { name: 'milk' },
+          { name: 'sugar' },
+          { name: 'butter' }
+        ]
+      }
+    },
+    Nutrition: {
+      description (params) {
+        return {
+          body: 'lorem ipsum'
+        }
+      }
+    },
+    NutritionDescription: {
+      other (params) {
+        return {
+          body: 'another string'
+        }
+      }
+    }
+  }
+
+  const query = `{
+    flavors {
+      id
+      name 
+      nutrition {
+        calories,
+        description {
+          body
+          other {
+            body
+          }
+        }
+      }
+      recipes {
+        name
+        ingredients {
+          name
+        }
+      }
+      seasons {
+        name
+      }
+    }
+  }`
+  const app = Fastify()
+
+  app.register(GQL, {
+    schema,
+    resolvers,
+    queryDepth: 5
+  })
+
+  // needed so that graphql is defined
+  await app.ready()
+
+  try {
+    const res = await app.graphql(query)
+    t.deepEqual(res, {
+      data: {
+        flavors: [
+          {
+            id: '1',
+            name: 'Strawberry',
+            nutrition: {
+              calories: 123,
+              description: {
+                body: 'lorem ipsum',
+                other: {
+                  body: 'another string'
+                }
+              }
+            },
+            recipes: [
+              {
+                name: 'Strawberry Cake',
+                ingredients: [
+                  { name: 'milk' },
+                  { name: 'sugar' },
+                  { name: 'butter' }
+                ]
+              },
+              {
+                name: 'Strawberry Ice Cream',
+                ingredients: [
+                  { name: 'milk' },
+                  { name: 'sugar' },
+                  { name: 'butter' }
+                ]
+              }
+            ],
+            seasons: [
+              { name: 'Spring' },
+              { name: 'Summer' }
+            ]
+          }
+        ]
+      }
+    })
+  } catch (error) {
+    console.log(error)
+    t.fail(error.message)
+  }
 })


### PR DESCRIPTION
@mcollina Not really sure if this new way of computing query depth covers all cases.
In the proposed test I used the following query
```
flavors {
      id
      name 
      nutrition {
        calories,
        description {
          body
          other {
            body
          }
        }
      }
      recipes {
        name
        ingredients {
          name
        }
      }
      seasons {
        name
      }
    }
```
which have a depth of 4 (`flavors -> nutrition -> description -> other`)
Fixes: #105 