### PR TITLE
renders graphiql if graphiql: true option is set

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -215,13 +215,13 @@ module.exports = async function (app, opts) {
     return reply.graphql(query, { pubsub: subscriber, ...context }, variables, operationName)
   })
 
-  if (opts.ide) {
+  if (opts.ide || opts.graphiql) {
     app.register(Static, {
       root: join(__dirname, '../static'),
       wildcard: false,
       serve: false
     })
-    if (opts.ide === true || opts.ide === 'graphiql') {
+    if (opts.ide === true || opts.ide === 'graphiql' || opts.graphiql === true) {
       app.get('/graphiql', (req, reply) => {
         reply.sendFile('graphiql.html')
       })

--- a/test/routes.js
+++ b/test/routes.js
@@ -1323,3 +1323,22 @@ test('disable GET graphiql if ide is not "graphiql" or "playground"', async (t) 
   })
   t.strictEqual(res2.statusCode, 404)
 })
+
+test('render graphiql if graphiql: true', async (t) => {
+  const app = Fastify()
+  app.register(GQL, {
+    graphiql: true
+  })
+
+  const res = await app.inject({
+    method: 'GET',
+    url: '/graphiql'
+  })
+  t.strictEqual(res.statusCode, 200)
+
+  const res2 = await app.inject({
+    method: 'GET',
+    url: '/playground'
+  })
+  t.strictEqual(res2.statusCode, 404)
+})


### PR DESCRIPTION
GraphiQL wasn't rendering if `graphiql: true` option was set, as in examples.
It was working, though, with `ide: true` or `ide: 'graphiql'`

Refs: #89