### PR TITLE
Improve Typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -145,7 +145,7 @@ declare module "fastify" {
       context?: any,
       variables?: { [key: string]: any },
       operationName?: string
-    ): FastifyReply<HttpResponse>;
+    ): Promise<ExecutionResult>;
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,10 @@
-import fastify, {
-  FastifyError,
-  FastifyReply,
-  FastifyRequest,
-  RegisterOptions
-} from "fastify"
+import fastify, { FastifyError, FastifyReply, FastifyRequest, RegisterOptions } from "fastify";
+import { DocumentNode, ExecutionResult, GraphQLSchema, Source } from 'graphql';
 import { IResolvers } from "graphql-tools";
-import { Server, IncomingMessage, ServerResponse } from "http";
+import { IncomingMessage, Server, ServerResponse } from "http";
 import { Http2Server, Http2ServerRequest, Http2ServerResponse } from 'http2';
-import graphql, { GraphQLSchema, GraphQLError, Source, DocumentNode, ExecutionResult } from 'graphql';
 
-declare namespace FastifyGQL {
+declare namespace fastifyGQL {
 
   export interface Plugin<HttpResponse> {
     /**
@@ -135,7 +130,7 @@ declare module "fastify" {
     /**
      * GraphQL plugin
      */
-    graphql: FastifyGQL.Plugin<HttpResponse>;
+    graphql: fastifyGQL.Plugin<HttpResponse>;
   }
 
   interface FastifyReply<HttpResponse> {
@@ -158,7 +153,7 @@ declare function fastifyGQL<
   HttpServer extends (Server | Http2Server),
   HttpRequest extends (IncomingMessage | Http2ServerRequest),
   HttpResponse extends (ServerResponse | Http2ServerResponse),
-  Options = FastifyGQL.Options<HttpServer, HttpRequest, HttpResponse>
+  Options = fastifyGQL.Options<HttpServer, HttpRequest, HttpResponse>
 >(
   fastify: fastify.FastifyInstance<HttpServer, HttpRequest, HttpResponse>,
   opts: Options): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,9 +41,9 @@ declare namespace fastifyGQL {
   }
 
   export interface Options<
-      HttpServer extends (Server | Http2Server),
-      HttpRequest extends (IncomingMessage | Http2ServerRequest),
-      HttpResponse extends (ServerResponse | Http2ServerResponse)
+      HttpServer extends (Server | Http2Server) = Server,
+      HttpRequest extends (IncomingMessage | Http2ServerRequest) = IncomingMessage,
+      HttpResponse extends (ServerResponse | Http2ServerResponse) = ServerResponse
     > extends RegisterOptions<HttpServer, HttpRequest, HttpResponse> {
     /**
      * The GraphQL schema. String schema will be parsed
@@ -150,9 +150,9 @@ declare module "fastify" {
 }
 
 declare function fastifyGQL<
-  HttpServer extends (Server | Http2Server),
-  HttpRequest extends (IncomingMessage | Http2ServerRequest),
-  HttpResponse extends (ServerResponse | Http2ServerResponse),
+  HttpServer extends (Server | Http2Server) = Server,
+  HttpRequest extends (IncomingMessage | Http2ServerRequest) = IncomingMessage,
+  HttpResponse extends (ServerResponse | Http2ServerResponse) = ServerResponse,
   Options = fastifyGQL.Options<HttpServer, HttpRequest, HttpResponse>
 >(
   fastify: fastify.FastifyInstance<HttpServer, HttpRequest, HttpResponse>,

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -87,3 +87,11 @@ app.get('/', async function (req, reply) {
 })
 
 app.listen(3000)
+
+function makeGraphqlServer(options: GQL.Options) {
+  const app = Fastify()
+
+  app.register(GQL, options)
+
+  return app
+}

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -88,10 +88,12 @@ app.get('/', async function (req, reply) {
 
 app.listen(3000)
 
-function makeGraphqlServer(options: GQL.Options) {
+function makeGraphqlServer (options: GQL.Options) {
   const app = Fastify()
 
   app.register(GQL, options)
 
   return app
 }
+
+makeGraphqlServer({ schema, resolvers })


### PR DESCRIPTION
This PR:

1. Improved TypeScripts types by naming the namespace and the plugin function using one symbol. This make sure that both the plugin its inner definitions (especially `Options`) are exported.
2 Fixed the return type of the graphql decorator. It was mistakenly reported as a fastify response, but it is actually the graphql execution result, and also it is always returned a promise.

Hope this helps!