### PR TITLE
Update GraphQL to version 15.0.0

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,5 @@
 import fastify, { FastifyError, FastifyReply, FastifyRequest, RegisterOptions } from "fastify";
-import { DocumentNode, ExecutionResult, GraphQLSchema, Source } from 'graphql';
-import { IResolvers } from "graphql-tools";
+import { DocumentNode, ExecutionResult, GraphQLSchema, Source, GraphQLResolveInfo, GraphQLIsTypeOfFn, GraphQLTypeResolver, GraphQLScalarType } from 'graphql';
 import { IncomingMessage, Server, ServerResponse } from "http";
 import { Http2Server, Http2ServerRequest, Http2ServerResponse } from 'http2';
 
@@ -163,3 +162,71 @@ declare function fastifyGQL<
   opts: Options): void;
 
 export = fastifyGQL;
+
+interface IResolvers<TSource = any, TContext = any> {
+  [key: string]: (() => any) | IResolverObject<TSource, TContext> | IResolverOptions<TSource, TContext> | GraphQLScalarType | IEnumResolver;
+}
+
+type IResolverObject<TSource = any, TContext = any, TArgs = any> = {
+  [key: string]: IFieldResolver<TSource, TContext, TArgs> | IResolverOptions<TSource, TContext> | IResolverObject<TSource, TContext>;
+};
+
+interface IResolverOptions<TSource = any, TContext = any, TArgs = any> {
+  fragment?: string;
+  resolve?: IFieldResolver<TSource, TContext, TArgs>;
+  subscribe?: IFieldResolver<TSource, TContext, TArgs>;
+  __resolveType?: GraphQLTypeResolver<TSource, TContext>;
+  __isTypeOf?: GraphQLIsTypeOfFn<TSource, TContext>;
+}
+
+type IEnumResolver = {
+  [key: string]: string | number;
+};
+
+type IFieldResolver<TSource, TContext, TArgs = Record<string, any>> = (source: TSource, args: TArgs, context: TContext, info: GraphQLResolveInfo & {
+  mergeInfo: MergeInfo;
+}) => any;
+
+type MergeInfo = {
+  delegate: (type: 'query' | 'mutation' | 'subscription', fieldName: string, args: {
+      [key: string]: any;
+  }, context: {
+      [key: string]: any;
+  }, info: GraphQLResolveInfo, transforms?: Array<Transform>) => any;
+  delegateToSchema<TContext>(options: IDelegateToSchemaOptions<TContext>): any;
+  fragments: Array<{
+      field: string;
+      fragment: string;
+  }>;
+};
+
+type Transform = {
+  transformSchema?: (schema: GraphQLSchema) => GraphQLSchema;
+  transformRequest?: (originalRequest: Request) => Request;
+  transformResult?: (result: Result) => Result;
+};
+
+interface IDelegateToSchemaOptions<TContext = {
+  [key: string]: any;
+}> {
+  schema: GraphQLSchema;
+  operation: Operation;
+  fieldName: string;
+  args?: {
+      [key: string]: any;
+  };
+  context: TContext;
+  info: IGraphQLToolsResolveInfo;
+  transforms?: Array<Transform>;
+  skipValidation?: boolean;
+}
+
+type Operation = 'query' | 'mutation' | 'subscription';
+
+type Result = ExecutionResult & {
+  extensions?: Record<string, any>;
+};
+
+interface IGraphQLToolsResolveInfo extends GraphQLResolveInfo {
+  mergeInfo?: MergeInfo;
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "fastify-plugin": "^1.6.0",
     "fastify-static": "^2.6.0",
     "fastify-websocket": "^1.0.0",
-    "graphql": "^14.6.0",
+    "graphql": "^15.0.0",
     "graphql-jit": "^0.4.0",
     "http-errors": "^1.7.3",
     "mqemitter": "^4.0.0",

--- a/tap-snapshots/test-federation.js-TAP.test.js
+++ b/tap-snapshots/test-federation.js-TAP.test.js
@@ -18,16 +18,10 @@ directive @customdir on FIELD_DEFINITION
 
 scalar _Any
 
-union _Entity = User | Product
-
 scalar _FieldSet
 
 type _Service {
   sdl: String
-}
-
-type Product {
-  sku: String
 }
 
 type Query {
@@ -36,10 +30,16 @@ type Query {
   _service: _Service!
 }
 
+type Product {
+  sku: String
+}
+
 type User {
   id: ID!
   name: String
   username: String
 }
+
+union _Entity = Product | User
 
 `

--- a/tap-snapshots/test-reply-decorator.js-TAP.test.js
+++ b/tap-snapshots/test-reply-decorator.js-TAP.test.js
@@ -6,5 +6,5 @@
  */
 'use strict'
 exports['test/reply-decorator.js TAP reply decorator set status code to 400 with bad query > must match snapshot 1'] = `
-{"errors":[{"message":"Syntax Error: Expected Name, found <EOF>","locations":[{"line":1,"column":18}]}]}
+{"errors":[{"message":"Syntax Error: Expected Name, found <EOF>.","locations":[{"line":1,"column":18}]}]}
 `

--- a/tap-snapshots/test-routes.js-TAP.test.js
+++ b/tap-snapshots/test-routes.js-TAP.test.js
@@ -53,7 +53,7 @@ exports['test/routes.js TAP POST return 400 on error > must match snapshot 1'] =
 {
   "errors": [
     {
-      "message": "Syntax Error: Expected Name, found <EOF>",
+      "message": "Syntax Error: Expected Name, found <EOF>.",
       "locations": [
         {
           "line": 1,

--- a/test/app-decorator.js
+++ b/test/app-decorator.js
@@ -379,7 +379,12 @@ test('extendSchema and defineResolvers throws without mutation definition', asyn
 
   const mutation = 'mutation { sub(x: 2, y: 2) }'
 
-  t.rejects(app.graphql(mutation), GraphQLError)
+  try {
+    await app.graphql(mutation)
+  } catch (e) {
+    t.is(e instanceof GraphQLError, true)
+    t.end()
+  }
 })
 
 test('basic GQL no cache', async (t) => {

--- a/test/routes.js
+++ b/test/routes.js
@@ -1050,7 +1050,7 @@ test('Error handler set to true should not change default behavior', async (t) =
 
   const expectedResult = {
     errors: [{
-      message: 'Expected type Int, found "2".',
+      message: 'Int cannot represent non-integer value: "2"',
       locations: [{
         line: 1,
         column: 8


### PR DESCRIPTION
This PR fixes the tests that are broken in #131.

The tests were broken because of changes in the error messages.

The Typescript check also failed because in the `node_modules/graphql-tools` package has two TS errors related to the schema stitching which is not used by this project at all. This can be avoided if the `IResolvers` type is not imported from the `graphql-tools` lib but included in the `types.d.ts` file.