### PR TITLE
Update `queryDepth` option docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ __fastify-gql__ supports the following options:
 * `prefix`: String. Change the route prefix of the graphql endpoint if enabled.
 * `defineMutation`: Boolean. Add the empty Mutation definition if schema is not defined (Default: `false`).
 * `errorHandler`: `Function`  or `boolean`. Change the default error handler (Default: `true`). _Note: If a custom error handler is defined, it should return the standardized response format according to [GraphQL spec](https://graphql.org/learn/serving-over-http/#response)._
-* `queryDepth`: `Integer`. The maximum depth allowed for a single query.
+* `queryDepth`: `Integer`. The maximum depth allowed for a single query. _Note: GraphiQL IDE (or Playground IDE) sends an introspection query when it starts up. This query has a depth of 7 so when the `queryDepth` value is smaller than 7 this query will fail with a `Bad Request` error_
 * `subscription`: Boolean | Object. Enable subscriptions. It is uses [mqemitter](https://github.com/mcollina/mqemitter) when it is true. To use a custom emitter set the value to an object containing the emitter.
   * `subscription.emitter`: Custom emitter
   * `subscription.verifyClient`: `Function` A function which can be used to validate incoming connections.


### PR DESCRIPTION
Updates the documentation and notes that the `queryDepth` value must be at least 7 if the introspection query should be allowed by the GraphiQL (or Playground) IDE. If it is smaller than 7 these queries will fail.