### PR TITLE
Extended errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,58 @@ gateway.register(GQL, {
 await gateway.listen(4000)
 ```
 
+### Use errors extension to provide additional information to query errors
+
+GraphQL services may provide an additional entry to errors with the key `extensions` in the result.
+
+```js
+'use strict'
+
+const Fastify = require('fastify')
+const GQL = require('./index')
+const { FastifyGraphQLError } = GQL
+
+const users = {
+  1: {
+    id: '1',
+    name: 'John'
+  },
+  2: {
+    id: '2',
+    name: 'Jane'
+  }
+}
+
+const app = Fastify()
+const schema = `
+  type Query {
+    findUser(id: String!): User
+  }
+
+  type User {
+    id: ID!
+    name: String
+  }
+`
+
+const resolvers = {
+  Query: {
+    findUser: (_, { id }) => {
+      const user = users[id]
+      if (user) return users[id]
+      else throw new FastifyGraphQLError('Invalid User ID', "USER_ID_INVALID", { id, timestamp: Math.round(new Date().getTime()/1000) })
+    }
+  }
+}
+
+app.register(GQL, {
+  schema,
+  resolvers
+})
+
+app.listen(3000)
+```
+
 ## API
 
 ### plugin options

--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ GraphQL services may provide an additional entry to errors with the key `extensi
 
 const Fastify = require('fastify')
 const GQL = require('./index')
-const { FastifyGraphQLError } = GQL
+const { ErrorWithProps } = GQL
 
 const users = {
   1: {
@@ -509,7 +509,7 @@ const resolvers = {
     findUser: (_, { id }) => {
       const user = users[id]
       if (user) return users[id]
-      else throw new FastifyGraphQLError('Invalid User ID', "USER_ID_INVALID", { id, timestamp: Math.round(new Date().getTime()/1000) })
+      else throw new ErrorWithProps('Invalid User ID', "USER_ID_INVALID", { id, timestamp: Math.round(new Date().getTime()/1000) })
     }
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -140,7 +140,7 @@ declare namespace fastifyGQL {
   /**
    * Extended errors for adding additional information in error responses
    */
-  export class FastifyGraphQLError extends Error {
+  export class ErrorWithProps extends Error {
     constructor (message: string, code?: string, additionalProperties?: object)
     /**
      * Custom error code of this error

--- a/index.d.ts
+++ b/index.d.ts
@@ -136,6 +136,21 @@ declare namespace fastifyGQL {
       }>
     }
   }
+
+  /**
+   * Extended errors for adding additional information in error responses
+   */
+  export class FastifyGraphQLError extends Error {
+    constructor (message: string, code?: string, additionalProperties?: object)
+    /**
+     * Custom error code of this error
+     */
+    code?: string
+    /**
+     * Custom additional properties of this error
+     */
+    additionalProperties?: object
+  } 
 }
 
 declare module "fastify" {
@@ -170,5 +185,6 @@ declare function fastifyGQL<
 >(
   fastify: fastify.FastifyInstance<HttpServer, HttpRequest, HttpResponse>,
   opts: Options): void;
+
 
 export = fastifyGQL;

--- a/index.js
+++ b/index.js
@@ -364,7 +364,7 @@ const plugin = fp(async function (app, opts) {
 
     if (execution.errors) {
       execution.errors = execution.errors.map(e => {
-        if (e.originalError instanceof ErrorWithProps) {
+        if (Object.prototype.hasOwnProperty.call(e.originalError, 'code') || Object.prototype.hasOwnProperty.call(e.originalError, 'additionalProperties')) {
           return new GraphQLError(e.originalError.message, e.nodes, e.source, e.positions, e.path, e.originalError, {
             code: e.originalError.code,
             ...e.originalError.additionalProperties

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ const buildFederationSchema = require('./lib/federation')
 const buildGateway = require('./lib/gateway')
 const mq = require('mqemitter')
 const { PubSub } = require('./lib/subscriber')
-const { FastifyGraphQLError } = require('./lib/errors')
+const { ErrorWithProps } = require('./lib/errors')
 
 const kLoaders = Symbol('fastify-gql.loaders')
 
@@ -364,7 +364,7 @@ const plugin = fp(async function (app, opts) {
 
     if (execution.errors) {
       execution.errors = execution.errors.map(e => {
-        if (e.originalError instanceof FastifyGraphQLError) {
+        if (e.originalError instanceof ErrorWithProps) {
           return new GraphQLError(e.originalError.message, e.nodes, e.source, e.positions, e.path, e.originalError, {
             code: e.originalError.code,
             ...e.originalError.additionalProperties
@@ -384,6 +384,6 @@ const plugin = fp(async function (app, opts) {
   name: 'fastify-gql'
 })
 
-plugin.FastifyGraphQLError = FastifyGraphQLError
+plugin.ErrorWithProps = ErrorWithProps
 
 module.exports = plugin

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function buildCache (opts) {
   return LRU(1024)
 }
 
-module.exports = fp(async function (app, opts) {
+const plugin = fp(async function (app, opts) {
   const lru = buildCache(opts)
   const lruErrors = buildCache(opts)
   const lruGatewayResolvers = buildCache(opts)
@@ -383,3 +383,7 @@ module.exports = fp(async function (app, opts) {
 }, {
   name: 'fastify-gql'
 })
+
+plugin.FastifyGraphQLError = FastifyGraphQLError
+
+module.exports = plugin

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,13 @@
+const { GraphQLError } = require('graphql')
+
+class FastifyGraphQLError extends GraphQLError {
+  constructor (message, code, additionalProperties) {
+    super(message)
+    this.code = code
+    this.additionalProperties = additionalProperties
+  }
+}
+
+module.exports = {
+  FastifyGraphQLError: FastifyGraphQLError
+}

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,6 +1,6 @@
-const { GraphQLError } = require('graphql')
+'use strict'
 
-class FastifyGraphQLError extends GraphQLError {
+class FastifyGraphQLError extends Error {
   constructor (message, code, additionalProperties) {
     super(message)
     this.code = code

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,6 +1,6 @@
 'use strict'
 
-class FastifyGraphQLError extends Error {
+class ErrorWithProps extends Error {
   constructor (message, code, additionalProperties) {
     super(message)
     this.code = code
@@ -9,5 +9,5 @@ class FastifyGraphQLError extends Error {
 }
 
 module.exports = {
-  FastifyGraphQLError: FastifyGraphQLError
+  ErrorWithProps: ErrorWithProps
 }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -37,6 +37,7 @@ const responseSchema = {
             },
             extensions: {
               type: 'object',
+              code: { type: 'string' },
               additionalProperties: true
             }
           }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -37,10 +37,7 @@ const responseSchema = {
             },
             extensions: {
               type: 'object',
-              properties: {
-                code: { type: 'string' },
-                timestamp: { type: 'string' }
-              }
+              additionalProperties: true
             }
           }
         }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -37,7 +37,9 @@ const responseSchema = {
             },
             extensions: {
               type: 'object',
-              code: { type: 'string' },
+              properties: {
+                code: { type: 'string' }
+              },
               additionalProperties: true
             }
           }

--- a/test/errors.js
+++ b/test/errors.js
@@ -5,64 +5,25 @@ const Fastify = require('fastify')
 const GQL = require('..')
 const { FastifyGraphQLError } = require('../lib/errors')
 
-const schema = `
-  type Query {
-    errorOne: String
-    errorTwo: String
-  }
-`
-
-const resolvers = {
-  Query: {
-    errorOne () {
-      throw new FastifyGraphQLError('Error One', 'ERROR_ONE', { additional: 'information one', other: 'data one' })
-    },
-    errorTwo () {
-      throw new FastifyGraphQLError('Error Two', 'ERROR_TWO', { additional: 'information two', other: 'data two' })
+test('errors - multiple custom errors', async (t) => {
+  const schema = `
+    type Query {
+      errorOne: String
+      errorTwo: String
     }
-  }
-}
+  `
 
-const goodPayload = {
-  data: {
-    errorOne: null,
-    errorTwo: null
-  },
-  errors: [
-    {
-      message: 'Error One',
-      locations: [
-        {
-          line: 1,
-          column: 2
-        }
-      ],
-      path: ['errorOne'],
-      extensions: {
-        code: 'ERROR_ONE',
-        additional: 'information one',
-        other: 'data one'
-      }
-    },
-    {
-      message: 'Error Two',
-      locations: [
-        {
-          line: 1,
-          column: 11
-        }
-      ],
-      path: ['errorTwo'],
-      extensions: {
-        code: 'ERROR_TWO',
-        additional: 'information two',
-        other: 'data two'
+  const resolvers = {
+    Query: {
+      errorOne () {
+        throw new FastifyGraphQLError('Error One', 'ERROR_ONE', { additional: 'information one', other: 'data one' })
+      },
+      errorTwo () {
+        throw new FastifyGraphQLError('Error Two', 'ERROR_TWO', { additional: 'information two', other: 'data two' })
       }
     }
-  ]
-}
+  }
 
-test('errors - test custom errors', async (t) => {
   const app = Fastify()
 
   app.register(GQL, {
@@ -79,5 +40,97 @@ test('errors - test custom errors', async (t) => {
   })
 
   t.equal(res.statusCode, 200)
-  t.deepEqual(JSON.parse(res.payload), goodPayload)
+  t.deepEqual(JSON.parse(res.payload), {
+    data: {
+      errorOne: null,
+      errorTwo: null
+    },
+    errors: [
+      {
+        message: 'Error One',
+        locations: [
+          {
+            line: 1,
+            column: 2
+          }
+        ],
+        path: ['errorOne'],
+        extensions: {
+          code: 'ERROR_ONE',
+          additional: 'information one',
+          other: 'data one'
+        }
+      },
+      {
+        message: 'Error Two',
+        locations: [
+          {
+            line: 1,
+            column: 11
+          }
+        ],
+        path: ['errorTwo'],
+        extensions: {
+          code: 'ERROR_TWO',
+          additional: 'information two',
+          other: 'data two'
+        }
+      }
+    ]
+  })
+})
+
+test('errors - custom errors with number additionalProperties', async (t) => {
+  const schema = `
+    type Query {
+      willThrow: String
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      willThrow () {
+        throw new FastifyGraphQLError('Custom Error', 'CUSTOM_ERROR', { floating: 3.14, timestamp: 1324356 })
+      }
+    }
+  }
+
+  const app = Fastify()
+
+  app.register(GQL, {
+    schema,
+    resolvers
+  })
+
+  // needed so that graphql is defined
+  await app.ready()
+
+  const res = await app.inject({
+    method: 'GET',
+    url: '/graphql?query={willThrow}'
+  })
+
+  t.equal(res.statusCode, 200)
+  t.deepEqual(JSON.parse(res.payload), {
+    data: {
+      willThrow: null
+    },
+    errors: [
+      {
+        message: 'Custom Error',
+        locations: [
+          {
+            line: 1,
+            column: 2
+          }
+        ],
+        path: ['willThrow'],
+        extensions: {
+          code: 'CUSTOM_ERROR',
+          floating: 3.14,
+          timestamp: 1324356
+        }
+      }
+    ]
+  })
 })

--- a/test/errors.js
+++ b/test/errors.js
@@ -1,0 +1,83 @@
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('fastify')
+const GQL = require('..')
+const { FastifyGraphQLError } = require('../lib/errors')
+
+const schema = `
+  type Query {
+    errorOne: String
+    errorTwo: String
+  }
+`
+
+const resolvers = {
+  Query: {
+    errorOne () {
+      throw new FastifyGraphQLError('Error One', 'ERROR_ONE', { additional: 'information one', other: 'data one' })
+    },
+    errorTwo () {
+      throw new FastifyGraphQLError('Error Two', 'ERROR_TWO', { additional: 'information two', other: 'data two' })
+    }
+  }
+}
+
+const goodPayload = {
+  data: {
+    errorOne: null,
+    errorTwo: null
+  },
+  errors: [
+    {
+      message: 'Error One',
+      locations: [
+        {
+          line: 1,
+          column: 2
+        }
+      ],
+      path: ['errorOne'],
+      extensions: {
+        code: 'ERROR_ONE',
+        additional: 'information one',
+        other: 'data one'
+      }
+    },
+    {
+      message: 'Error Two',
+      locations: [
+        {
+          line: 1,
+          column: 11
+        }
+      ],
+      path: ['errorTwo'],
+      extensions: {
+        code: 'ERROR_TWO',
+        additional: 'information two',
+        other: 'data two'
+      }
+    }
+  ]
+}
+
+test('errors - test custom errors', async (t) => {
+  const app = Fastify()
+
+  app.register(GQL, {
+    schema,
+    resolvers
+  })
+
+  // needed so that graphql is defined
+  await app.ready()
+
+  const res = await app.inject({
+    method: 'GET',
+    url: '/graphql?query={errorOne,errorTwo}'
+  })
+
+  t.equal(res.statusCode, 200)
+  t.deepEqual(JSON.parse(res.payload), goodPayload)
+})

--- a/test/errors.js
+++ b/test/errors.js
@@ -139,7 +139,7 @@ test('errors - extended errors with number additionalProperties', async (t) => {
   })
 })
 
-test('errors - extended errors optionals parameters', async (t) => {
+test('errors - extended errors optional parameters', async (t) => {
   const schema = `
     type Query {
       one: String

--- a/test/errors.js
+++ b/test/errors.js
@@ -3,7 +3,7 @@
 const { test } = require('tap')
 const Fastify = require('fastify')
 const GQL = require('..')
-const { FastifyGraphQLError } = GQL
+const { ErrorWithProps } = GQL
 
 test('errors - multiple extended errors', async (t) => {
   const schema = `
@@ -17,10 +17,10 @@ test('errors - multiple extended errors', async (t) => {
   const resolvers = {
     Query: {
       errorOne () {
-        throw new FastifyGraphQLError('Error One', 'ERROR_ONE', { additional: 'information one', other: 'data one' })
+        throw new ErrorWithProps('Error One', 'ERROR_ONE', { additional: 'information one', other: 'data one' })
       },
       errorTwo () {
-        throw new FastifyGraphQLError('Error Two', 'ERROR_TWO', { additional: 'information two', other: 'data two' })
+        throw new ErrorWithProps('Error Two', 'ERROR_TWO', { additional: 'information two', other: 'data two' })
       },
       successful () {
         return 'Runs OK'
@@ -94,7 +94,7 @@ test('errors - extended errors with number additionalProperties', async (t) => {
   const resolvers = {
     Query: {
       willThrow () {
-        throw new FastifyGraphQLError('Extended Error', 'EXTENDED_ERROR', { floating: 3.14, timestamp: 1324356, reason: 'some reason' })
+        throw new ErrorWithProps('Extended Error', 'EXTENDED_ERROR', { floating: 3.14, timestamp: 1324356, reason: 'some reason' })
       }
     }
   }
@@ -152,16 +152,16 @@ test('errors - extended errors optionals parameters', async (t) => {
   const resolvers = {
     Query: {
       one () {
-        throw new FastifyGraphQLError('Extended Error')
+        throw new ErrorWithProps('Extended Error')
       },
       two () {
-        throw new FastifyGraphQLError('Extended Error', 'ERROR_TWO')
+        throw new ErrorWithProps('Extended Error', 'ERROR_TWO')
       },
       three () {
-        throw new FastifyGraphQLError('Extended Error', 'ERROR_THREE', { reason: 'some reason' })
+        throw new ErrorWithProps('Extended Error', 'ERROR_THREE', { reason: 'some reason' })
       },
       four () {
-        throw new FastifyGraphQLError('Extended Error', undefined, { reason: 'some reason' })
+        throw new ErrorWithProps('Extended Error', undefined, { reason: 'some reason' })
       }
     }
   }

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1,5 +1,5 @@
 import Fastify from 'fastify'
-import GQL from '../..'
+import GQL, { ErrorWithProps } from '../..'
 
 const app = Fastify()
 
@@ -52,18 +52,18 @@ app.register(GQL, {
 
 app.register(async function (app) {
   app.graphql.extendSchema(`
-  type Human {
-    name: String!
-  }
+    type Human {
+      name: String!
+    }
 
-  type Dog {
-    name: String!
-    owner: Human
-  }
+    type Dog {
+      name: String!
+      owner: Human
+    }
 
-  type Query {
-    dogs: [Dog]
-  }
+    type Query {
+      dogs: [Dog]
+    }
   `)
   app.graphql.defineResolvers({
     Query: {
@@ -77,6 +77,19 @@ app.register(async function (app) {
       async owner (queries: Array<{ obj: { name: keyof typeof owners } }>) {
         return queries.map(({ obj }) => owners[obj.name])
       }
+    }
+  })
+})
+
+app.register(async function (app) {
+  app.graphql.extendSchema(`
+    type Query {
+      willThrow: String
+    }
+  `)
+  app.graphql.defineResolvers({
+    Query: {
+      willThrow: async () => { throw new ErrorWithProps('Extended Error', 'EXTENDED_ERROR', { reason: 'some reason', other: 32 }) }
     }
   })
 })


### PR DESCRIPTION
This is a PR for adding feature described in #144 

I'd like for some input on my implementation and naming. 
- Is `FastifyGraphQLError` class for the extended error suitable?
- How should we structure the error parameters? At the moment I'm using Apollo's `ApolloError` format; i.e. `(message: string, code: string, additionalProperties: object)`