### PR TITLE
Variable validation before query execution

### DIFF
--- a/index.js
+++ b/index.js
@@ -326,16 +326,6 @@ const plugin = fp(async function (app, opts) {
         throw err
       }
 
-      // Validate variables
-      if (variables !== undefined) {
-        const executionContext = buildExecutionContext(schema, document, root, context, variables, operationName)
-        if (Array.isArray(executionContext)) {
-          const err = new BadRequest()
-          err.errors = executionContext
-          throw err
-        }
-      }
-
       if (queryDepthLimit) {
         const queryDepthErrors = queryDepth(document.definitions, queryDepthLimit)
 
@@ -371,6 +361,16 @@ const plugin = fp(async function (app, opts) {
     if (cached && cached.jit !== null) {
       const res = await cached.jit.query(root, context, variables || {})
       return res
+    }
+
+    // Validate variables
+    if (variables !== undefined) {
+      const executionContext = buildExecutionContext(schema, document, root, context, variables, operationName)
+      if (Array.isArray(executionContext)) {
+        const err = new BadRequest()
+        err.errors = executionContext
+        throw err
+      }
     }
 
     const execution = await execute(

--- a/test/routes.js
+++ b/test/routes.js
@@ -198,6 +198,60 @@ test('GET route with bad JSON variables', async (t) => {
   t.is(res.statusCode, 400)
 })
 
+test('GET route with insufficient variables', async (t) => {
+  const app = Fastify()
+  const schema = `
+    type Query {
+      add(x: Int, y: Int): Int
+    }
+  `
+
+  const resolvers = {
+    add: async ({ x, y }) => x + y
+  }
+
+  app.register(GQL, {
+    schema,
+    resolvers
+  })
+
+  const query = 'query ($x: Int!, $y: Int!) { add(x: $x, y: $y) }'
+
+  const res = await app.inject({
+    method: 'GET',
+    url: `/graphql?query=${query}&variables=${JSON.stringify({ x: 5 })}`
+  })
+
+  t.is(res.statusCode, 400)
+})
+
+test('GET route with mistyped variables', async (t) => {
+  const app = Fastify()
+  const schema = `
+    type Query {
+      add(x: Int, y: Int): Int
+    }
+  `
+
+  const resolvers = {
+    add: async ({ x, y }) => x + y
+  }
+
+  app.register(GQL, {
+    schema,
+    resolvers
+  })
+
+  const query = 'query ($x: Int!, $y: Int!) { add(x: $x, y: $y) }'
+
+  const res = await app.inject({
+    method: 'GET',
+    url: `/graphql?query=${query}&variables=${JSON.stringify({ x: 5, y: 'wrong data' })}`
+  })
+
+  t.is(res.statusCode, 400)
+})
+
 test('POST route variables', async (t) => {
   const app = Fastify()
   const schema = `

--- a/test/routes.js
+++ b/test/routes.js
@@ -198,7 +198,7 @@ test('GET route with bad JSON variables', async (t) => {
   t.is(res.statusCode, 400)
 })
 
-test('GET route with insufficient variables', async (t) => {
+test('GET route with missing variables', async (t) => {
   const app = Fastify()
   const schema = `
     type Query {


### PR DESCRIPTION
I found an inconsistency in returned error codes when handling user input errors. Syntax errors in queries will cause `Bad Request` (400) error, which is correct. However missing variables such as this example:

```js
const app = Fastify();
const schema = `
    type Query {
      add(x: Int, y: Int): Int
    }
  `;

const resolvers = {
  add: async ({ x, y }) => x + y,
};

app.register(GQL, {
  schema,
  resolvers,
});

const query = "query ($x: Int!, $y: Int!) { add(x: $x, y: $y) }";

const res = await app.inject({
  method: "GET",
  url: `/graphql?query=${query}&variables=${JSON.stringify({ x: 5 })}`, // notice there's no 'y' 
});

```

Along with other errors related to query variables like mis-typed variables would cause `Internal Server Error` (500) errors which isn't correct since this problem is coming from the client-side providing wrong variables. 

In this PR I added variable validation just before the execution of the query to produce `Bad Request` (400) error on invalid variables without affecting execution errors.

I also added a test case for requests with missing variables scenario I described above.