### PR TITLE
fix: add @extends federation directive

### DIFF
--- a/lib/federation.js
+++ b/lib/federation.js
@@ -43,6 +43,7 @@ const BASE_FEDERATION_TYPES = `
   directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
   directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
   directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
+  directive @extends on OBJECT | INTERFACE
 `
 
 const FEDERATION_SCHEMA = `

--- a/tap-snapshots/test-federation.js-TAP.test.js
+++ b/tap-snapshots/test-federation.js-TAP.test.js
@@ -14,6 +14,8 @@ directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 
 directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
 
+directive @extends on OBJECT | INTERFACE
+
 directive @customdir on FIELD_DEFINITION
 
 scalar _Any


### PR DESCRIPTION
Hello. Adding the missing directive that will allow to use `type U @extends { ... }` alongside with `extend U { ... }`

Please see the [docs](https://www.apollographql.com/docs/apollo-server/federation/federation-spec/#create-stub-types):

> Some libraries such as `graphql-java` don't have native support for type extensions in their printer. Apollo Federation supports using an `@extends` directive in place of extend type to annotate type references:

```
type User @key(fields: "id") @extends {
  id: ID! @external
  reviews: [Review]
}
```

Without this, `fastify-gql` will fail with something like
```
"msg":"Unknown directive \"extends\".",
"stack":"Error: Unknown directive \"extends\".\n
    at assertValidSDLExtension (/node_modules/fastify-gql/node_modules/graphql/validation/validate.js:125:11)
    at extendSchema (/node_modules/fastify-gql/node_modules/graphql/utilities/extendSchema.js:71:43)
    at buildFederationSchema (/node_modules/fastify-gql/lib/federation.js:231:22)
    at buildGateway (/node_modules/fastify-gql/lib/gateway.js:141:18)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async fp.name (/node_modules/fastify-gql/index.js:118:15)"
```