### PR TITLE
feat: improve error handling for federation queries

### DIFF
--- a/lib/gateway/request.js
+++ b/lib/gateway/request.js
@@ -87,6 +87,11 @@ function sendRequest (request, url) {
 
           try {
             const json = JSON.parse(data.toString())
+
+            if (json.errors && json.errors.length) {
+              return reject(json.errors)
+            }
+
             resolve({
               statusCode: response.statusCode,
               json

--- a/test/gateway/request.js
+++ b/test/gateway/request.js
@@ -49,3 +49,38 @@ test('sendRequest method rejects when response is not valid json', async (t) => 
 
   t.end()
 })
+
+test('sendRequest method rejects when response contains errors', async (t) => {
+  const app = fastify()
+  app.post('/', async (request, reply) => {
+    return { errors: ['foo'] }
+  })
+
+  await app.listen(0)
+
+  const url = new URL(`http://localhost:${app.server.address().port}`)
+  const { request, close } = buildRequest({})
+  t.tearDown(() => {
+    close()
+    app.close()
+  })
+  t.rejects(
+    sendRequest(
+      request,
+      url
+    )({
+      method: 'POST',
+      body: JSON.stringify({
+        query: `
+      query ServiceInfo {
+        _service {
+          sdl
+        }
+      }
+      `
+      })
+    })
+  )
+
+  t.end()
+})


### PR DESCRIPTION
Graphql errors in the gateway are not handled in any way. So response on underlying error will be like 
```json
{
  "error": {
    "errors": [
      {
        "message": "Cannot read property 'foo' of null",
        "locations": [
          {
            "line": 2,
            "column": 3
          }
        ],
        "path": [
          "payments"
        ]
      }
    ],
    "data": null
  }
}
```

Instead, with this change, we will see something like

```json
{
  "error": {
    "errors": [
      {
        "message": "Unexpected error value: [{ message: \"invalid token\", locations: [Array], path: [Array], extensions: [Object] }]",
        "locations": [
          {
            "line": 2,
            "column": 3
          }
        ],
        "path": [
          "foo"
        ]
      }
    ],
    "data": null
  }
}
```

which will slightly improve debugging experience