### PR TITLE
Generate correct resolver for fields returning scalar

### DIFF
--- a/examples/gateway.js
+++ b/examples/gateway.js
@@ -61,6 +61,7 @@ async function start () {
   await createService(4001, `
     extend type Query {
       me: User
+      hello: String
     }
 
     type User @key(fields: "id") {
@@ -80,7 +81,8 @@ async function start () {
     Query: {
       me: (root, args, context, info) => {
         return users.u1
-      }
+      },
+      hello: () => 'world'
     },
     User: {
       __resolveReference: (user, args, context, info) => {
@@ -113,6 +115,7 @@ async function start () {
 
     extend type Mutation {
       createPost(post: PostInput!): Post
+      updateHello: String
     }
 
     input PostInput {
@@ -154,7 +157,8 @@ async function start () {
         posts[pid] = result
 
         return result
-      }
+      },
+      updateHello: () => 'World'
     }
   })
 

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -120,11 +120,21 @@ function defineResolvers (schema, typeToServiceMap, serviceMap, typeFieldsToServ
             }
           }
         } else if (typeFieldsToService[`${type}-${fieldName}`]) {
-          field.resolve = makeResolver({
-            service: serviceMap[typeFieldsToService[`${type}-${fieldName}`]],
-            createOperation: createFieldResolverOperation,
-            transformData: response => response.json.data._entities[0][fieldName]
-          })
+          const service = serviceMap[typeFieldsToService[`${type}-${fieldName}`]]
+          if (serviceForType === null) {
+            field.resolve = makeResolver({
+              service,
+              createOperation: createQueryOperation,
+              transformData: response => response.json.data[fieldName],
+              isQuery: true
+            })
+          } else {
+            field.resolve = makeResolver({
+              service,
+              createOperation: createFieldResolverOperation,
+              transformData: response => response.json.data._entities[0][fieldName]
+            })
+          }
         }
       }
     }

--- a/test/gateway/schema.js
+++ b/test/gateway/schema.js
@@ -65,6 +65,7 @@ test('It builds the gateway schema correctly', async (t) => {
   const userServicePort = await createService(t, `
     extend type Query {
       me: User
+      hello: String
     }
 
     type User @key(fields: "id") {
@@ -83,7 +84,8 @@ test('It builds the gateway schema correctly', async (t) => {
     Query: {
       me: (root, args, context, info) => {
         return users.u1
-      }
+      },
+      hello: () => 'World'
     },
     User: {
       __resolveReference: (user, args, context, info) => {
@@ -185,6 +187,7 @@ test('It builds the gateway schema correctly', async (t) => {
     topPosts(count: $count) {
       ...PostFragment
     }
+    hello
   }
   
   fragment UserFragment on User {
@@ -290,7 +293,8 @@ test('It builds the gateway schema correctly', async (t) => {
           avatar: 'avatar-medium.jpg',
           numberOfPosts: 2
         }
-      }]
+      }],
+      hello: 'World'
     }
   })
 })


### PR DESCRIPTION
When generating resolvers for fields with scalar return types, the gateway always assumed that the field is not on the `Query` or `Mutation` and created an `Entity` resolver. This resulted in an error (#158) when the schema contained a field like the following:
```
type Query {
  hello: String
}
```

This PR adds a check to the resolver generation and if the field is on the `Query` or `Mutation` type it assigns the correct resolver.
