### PR TITLE
Fixes missing error extensions when query is jit'ed

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ const resolvers = {
     findUser: (_, { id }) => {
       const user = users[id]
       if (user) return users[id]
-      else throw new ErrorWithProps('Invalid User ID', "USER_ID_INVALID", { id, timestamp: Math.round(new Date().getTime()/1000) })
+      else throw new ErrorWithProps('Invalid User ID', { id, code: "USER_ID_INVALID", timestamp: Math.round(new Date().getTime()/1000) })
     }
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -140,15 +140,11 @@ declare namespace fastifyGQL {
    * Extended errors for adding additional information in error responses
    */
   export class ErrorWithProps extends Error {
-    constructor (message: string, code?: string, additionalProperties?: object)
-    /**
-     * Custom error code of this error
-     */
-    code?: string
+    constructor (message: string, extensions?: object)
     /**
      * Custom additional properties of this error
      */
-    additionalProperties?: object
+    extensions?: object
   } 
 }
 

--- a/index.js
+++ b/index.js
@@ -384,11 +384,8 @@ const plugin = fp(async function (app, opts) {
 
     if (execution.errors) {
       execution.errors = execution.errors.map(e => {
-        if (e.originalError && (Object.prototype.hasOwnProperty.call(e.originalError, 'code') || Object.prototype.hasOwnProperty.call(e.originalError, 'additionalProperties'))) {
-          return new GraphQLError(e.originalError.message, e.nodes, e.source, e.positions, e.path, e.originalError, {
-            code: e.originalError.code,
-            ...e.originalError.additionalProperties
-          })
+        if (e.originalError && (Object.prototype.hasOwnProperty.call(e.originalError, 'extensions'))) {
+          return new GraphQLError(e.originalError.message, e.nodes, e.source, e.positions, e.path, e.originalError, e.originalError.extensions)
         }
         return e
       })

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,10 +1,9 @@
 'use strict'
 
 class ErrorWithProps extends Error {
-  constructor (message, code, additionalProperties) {
+  constructor (message, extensions) {
     super(message)
-    this.code = code
-    this.additionalProperties = additionalProperties
+    this.extensions = extensions
   }
 }
 

--- a/test/errors.js
+++ b/test/errors.js
@@ -17,10 +17,10 @@ test('errors - multiple extended errors', async (t) => {
   const resolvers = {
     Query: {
       errorOne () {
-        throw new ErrorWithProps('Error One', 'ERROR_ONE', { additional: 'information one', other: 'data one' })
+        throw new ErrorWithProps('Error One', { code: 'ERROR_ONE', additional: 'information one', other: 'data one' })
       },
       errorTwo () {
-        throw new ErrorWithProps('Error Two', 'ERROR_TWO', { additional: 'information two', other: 'data two' })
+        throw new ErrorWithProps('Error Two', { code: 'ERROR_TWO', additional: 'information two', other: 'data two' })
       },
       successful () {
         return 'Runs OK'
@@ -84,7 +84,7 @@ test('errors - multiple extended errors', async (t) => {
   })
 })
 
-test('errors - extended errors with number additionalProperties', async (t) => {
+test('errors - extended errors with number extensions', async (t) => {
   const schema = `
     type Query {
       willThrow: String
@@ -94,7 +94,7 @@ test('errors - extended errors with number additionalProperties', async (t) => {
   const resolvers = {
     Query: {
       willThrow () {
-        throw new ErrorWithProps('Extended Error', 'EXTENDED_ERROR', { floating: 3.14, timestamp: 1324356, reason: 'some reason' })
+        throw new ErrorWithProps('Extended Error', { code: 'EXTENDED_ERROR', floating: 3.14, timestamp: 1324356, reason: 'some reason' })
       }
     }
   }
@@ -155,13 +155,7 @@ test('errors - extended errors optional parameters', async (t) => {
         throw new ErrorWithProps('Extended Error')
       },
       two () {
-        throw new ErrorWithProps('Extended Error', 'ERROR_TWO')
-      },
-      three () {
-        throw new ErrorWithProps('Extended Error', 'ERROR_THREE', { reason: 'some reason' })
-      },
-      four () {
-        throw new ErrorWithProps('Extended Error', undefined, { reason: 'some reason' })
+        throw new ErrorWithProps('Extended Error', { code: 'ERROR_TWO', reason: 'some reason' })
       }
     }
   }
@@ -177,16 +171,14 @@ test('errors - extended errors optional parameters', async (t) => {
 
   const res = await app.inject({
     method: 'GET',
-    url: '/graphql?query={one,two,three,four}'
+    url: '/graphql?query={one,two}'
   })
 
   t.equal(res.statusCode, 200)
   t.deepEqual(JSON.parse(res.payload), {
     data: {
       one: null,
-      two: null,
-      three: null,
-      four: null
+      two: null
     },
     errors: [
       {
@@ -197,8 +189,7 @@ test('errors - extended errors optional parameters', async (t) => {
             column: 2
           }
         ],
-        path: ['one'],
-        extensions: {}
+        path: ['one']
       },
       {
         message: 'Extended Error',
@@ -210,33 +201,7 @@ test('errors - extended errors optional parameters', async (t) => {
         ],
         path: ['two'],
         extensions: {
-          code: 'ERROR_TWO'
-        }
-      },
-      {
-        message: 'Extended Error',
-        locations: [
-          {
-            line: 1,
-            column: 10
-          }
-        ],
-        path: ['three'],
-        extensions: {
-          code: 'ERROR_THREE',
-          reason: 'some reason'
-        }
-      },
-      {
-        message: 'Extended Error',
-        locations: [
-          {
-            line: 1,
-            column: 16
-          }
-        ],
-        path: ['four'],
-        extensions: {
+          code: 'ERROR_TWO',
           reason: 'some reason'
         }
       }

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -89,7 +89,7 @@ app.register(async function (app) {
   `)
   app.graphql.defineResolvers({
     Query: {
-      willThrow: async () => { throw new ErrorWithProps('Extended Error', 'EXTENDED_ERROR', { reason: 'some reason', other: 32 }) }
+      willThrow: async () => { throw new ErrorWithProps('Extended Error', { code: 'EXTENDED_ERROR', reason: 'some reason', other: 32 }) }
     }
   })
 })


### PR DESCRIPTION
Fixes #164 

Removes explicit `code` field in `ErrorWithProps` and renames `additionalProperties` field to `extensions`.