### PR TITLE
fix: move ws from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "snazzy": "^8.0.0",
     "standard": "^14.0.0",
     "tap": "^14.10.6",
-    "typescript": "^3.7.5",
-    "ws": "^7.2.1"
+    "typescript": "^3.7.5"
   },
   "dependencies": {
     "end-of-stream": "^1.4.4",
@@ -50,6 +49,7 @@
     "p-map": "^4.0.0",
     "readable-stream": "^3.5.0",
     "single-user-cache": "^0.3.0",
-    "tiny-lru": "^7.0.2"
+    "tiny-lru": "^7.0.2",
+    "ws": "^7.2.1"
   }
 }


### PR DESCRIPTION
The `ws` package is also used in the `lib/gateway/service-map.js` module, it should be a dependency and not a devDependency