### PR TITLE
Fix failing tests

### DIFF
--- a/test/routes.js
+++ b/test/routes.js
@@ -869,8 +869,20 @@ test('GET graphiql endpoint with prefix', async (t) => {
 
 test('GET graphiql endpoint with prefixed wrapper', async (t) => {
   const app = Fastify()
+  const schema = `
+    type Query {
+      add(x: Int, y: Int): Int
+    }
+  `
+
+  const resolvers = {
+    add: async ({ x, y }) => x + y
+  }
+
   app.register(async function (app, opts) {
     app.register(GQL, {
+      schema,
+      resolvers,
       ide: 'graphiql'
     })
   }, { prefix: '/test-wrapper-prefix' })
@@ -913,8 +925,20 @@ test('GET graphql playground endpoint with prefix', async (t) => {
 
 test('GET graphql playground endpoint with prefixed wrapper', async (t) => {
   const app = Fastify()
+  const schema = `
+    type Query {
+      add(x: Int, y: Int): Int
+    }
+  `
+
+  const resolvers = {
+    add: async ({ x, y }) => x + y
+  }
+
   app.register(async function (app, opts) {
     app.register(GQL, {
+      schema,
+      resolvers,
       ide: 'playground'
     })
   }, { prefix: '/test-wrapper-prefix' })

--- a/test/subscription.js
+++ b/test/subscription.js
@@ -225,9 +225,21 @@ test('subscription server sends update to subscriptions', t => {
 
 test('subscription server register handle function arg is not empty', t => {
   const app = Fastify()
+  const schema = `
+    type Query {
+      add(x: Int, y: Int): Int
+    }
+  `
+
+  const resolvers = {
+    add: async ({ x, y }) => x + y
+  }
+
   t.tearDown(app.close)
 
   app.register(GQL, {
+    schema,
+    resolvers,
     subscription: true
   })
 
@@ -250,8 +262,20 @@ test('subscription server register handle function arg is not empty', t => {
 
 test('subscription socket protocol different than graphql-ws, protocol = foobar', t => {
   const app = Fastify()
+  const schema = `
+    type Query {
+      add(x: Int, y: Int): Int
+    }
+  `
+
+  const resolvers = {
+    add: async ({ x, y }) => x + y
+  }
+
   t.tearDown(app.close)
   app.register(GQL, {
+    schema,
+    resolvers,
     subscription: true
   })
 


### PR DESCRIPTION
I'm not particularly familiar with the codebase, so I'm not sure if this is the *proper* fix.
With these changes I no longer experience the failing tests.

---

At the time of this fix, these tests were passing on Travis, however,
failed on my Mac locally running on node v12.18.1.

After a little digging, the underlying error seemed to be related to
schema validation issues, occurring when calling validateSchema
function within app.ready(...).
It seems to be a valid error that happens when attempting to initialize
app with invalid schema, however, I'm unsure why I encountered it
and not other contributors (including CI).