### PR TITLE
Allow using graphql request metadata when defining validationRules

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ __fastify-gql__ supports the following options:
 * `defineMutation`: Boolean. Add the empty Mutation definition if schema is not defined (Default: `false`).
 * `errorHandler`: `Function`  or `boolean`. Change the default error handler (Default: `true`). _Note: If a custom error handler is defined, it should return the standardized response format according to [GraphQL spec](https://graphql.org/learn/serving-over-http/#response)._
 * `queryDepth`: `Integer`. The maximum depth allowed for a single query. _Note: GraphiQL IDE (or Playground IDE) sends an introspection query when it starts up. This query has a depth of 7 so when the `queryDepth` value is smaller than 7 this query will fail with a `Bad Request` error_
-* `validationRules`: `Function[]`. Optional additional validation rules that the queries must satisfy in addition to those defined by the GraphQL specification.
+* `validationRules`: `Function` or `Function[]`. Optional additional validation rules that the queries must satisfy in addition to those defined by the GraphQL specification. When using `Function`, arguments include additional data from graphql request and the return value must be validation rules `Function[]`.
 * `subscription`: Boolean | Object. Enable subscriptions. It is uses [mqemitter](https://github.com/mcollina/mqemitter) when it is true. To use a custom emitter set the value to an object containing the emitter.
   * `subscription.emitter`: Custom emitter
   * `subscription.verifyClient`: `Function` A function which can be used to validate incoming connections.

--- a/index.d.ts
+++ b/index.d.ts
@@ -118,7 +118,7 @@ declare namespace fastifyGQL {
      * Optional additional validation rules.
      * Queries must satisfy these rules in addition to those defined by the GraphQL specification.
      */
-    validationRules?: (params: { source: string, variables?: Record<string, any>, operationName?: string }) => ValidationRule[],
+    validationRules?: ValidationRules,
     context?: (request: FastifyRequest<HttpRequest>, reply: FastifyReply<HttpResponse>) => Promise<any>,
     /**
      * Enable subscription support when options are provided. [`emitter`](https://github.com/mcollina/mqemitter) property is required when subscriptions is an object. (Default false)
@@ -272,3 +272,5 @@ type Request = {
   variables: Record<string, any>;
   extensions?: Record<string, any>;
 };
+
+type ValidationRules = ValidationRule[] | ((params: { source: string, variables?: Record<string, any>, operationName?: string }) => ValidationRule[])

--- a/index.d.ts
+++ b/index.d.ts
@@ -118,7 +118,7 @@ declare namespace fastifyGQL {
      * Optional additional validation rules.
      * Queries must satisfy these rules in addition to those defined by the GraphQL specification.
      */
-    validationRules?: ValidationRule[],
+    validationRules?: (params: { source: string, variables?: Record<string, any>, operationName?: string }) => ValidationRule[],
     context?: (request: FastifyRequest<HttpRequest>, reply: FastifyReply<HttpResponse>) => Promise<any>,
     /**
      * Enable subscription support when options are provided. [`emitter`](https://github.com/mcollina/mqemitter) property is required when subscriptions is an object. (Default false)

--- a/index.js
+++ b/index.js
@@ -81,8 +81,6 @@ const plugin = fp(async function (app, opts) {
   let subscriber
   let verifyClient
 
-  const validationRules = [...specifiedRules, ...(opts.validationRules || [])]
-
   if (typeof subscriptionOpts === 'object') {
     emitter = subscriptionOpts.emitter || mq()
     verifyClient = subscriptionOpts.verifyClient
@@ -321,7 +319,8 @@ const plugin = fp(async function (app, opts) {
       }
 
       // Validate
-      const validationErrors = validate(fastifyGraphQl.schema, document, validationRules)
+      const validationRules = opts.validationRules ? opts.validationRules({ source, variables, operationName }) : []
+      const validationErrors = validate(fastifyGraphQl.schema, document, [...specifiedRules, ...validationRules])
 
       if (validationErrors.length > 0) {
         if (lruErrors) {

--- a/index.js
+++ b/index.js
@@ -319,7 +319,14 @@ const plugin = fp(async function (app, opts) {
       }
 
       // Validate
-      const validationRules = opts.validationRules ? opts.validationRules({ source, variables, operationName }) : []
+      let validationRules = []
+      if (opts.validationRules) {
+        if (Array.isArray(opts.validationRules)) {
+          validationRules = opts.validationRules
+        } else {
+          validationRules = opts.validationRules({ source, variables, operationName })
+        }
+      }
       const validationErrors = validate(fastifyGraphQl.schema, document, [...specifiedRules, ...validationRules])
 
       if (validationErrors.length > 0) {

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1,4 +1,6 @@
 import Fastify from 'fastify'
+// eslint-disable-next-line no-unused-vars
+import { ValidationContext, ValidationRule } from 'graphql'
 import GQL, { ErrorWithProps } from '../..'
 
 const app = Fastify()
@@ -109,4 +111,15 @@ function makeGraphqlServer (options: GQL.Options) {
   return app
 }
 
+const customValidationRule: ValidationRule = (_context: ValidationContext) => {
+  return {
+    Document () {
+      return false
+    }
+  }
+}
+
 makeGraphqlServer({ schema, resolvers })
+makeGraphqlServer({ schema, resolvers, validationRules: [] })
+makeGraphqlServer({ schema, resolvers, validationRules: [customValidationRule] })
+makeGraphqlServer({ schema, resolvers, validationRules: ({ variables, operationName, source }) => [customValidationRule] })

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "noEmit": true,
     "strict": true,
-    "esModuleInterop": true,
+    "esModuleInterop": true
   },
   "exclude": ["node_modules", "**/node_modules/*"],
   "files": [


### PR DESCRIPTION
Graphql validation context does not include variables and operationName, however those are often needed when defining custom validation rules.

These changes allow initializing custom validation rules and passing the the graphql request metadata in the function.
I'm using `params` as an object to make it easier to add new properties a bit easier in the future.

I'm a bit unsure if it's necessary to add extra validation for `opts.validationRules` to ensure it's a function and returned value an iterable.