### PR TITLE
Update signature of addContentTypeParser

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -274,13 +274,8 @@ module.exports = async function (app, opts) {
     app.route(getOptions)
   }
 
-  app.addContentTypeParser('application/graphql', function (req, done) {
-    req.setEncoding('utf8')
-    var data = ''
-    req.on('data', chunk => { data += chunk })
-    req.on('end', _ => {
-      done(null, { query: data })
-    })
+  app.addContentTypeParser('application/graphql', { parseAs: 'string' }, function (req, payload, done) {
+    done(null, { query: payload })
   })
 
   app.post(graphqlPath, {


### PR DESCRIPTION
To comply with Fastify v3.

This is the outcome of https://github.com/mcollina/fastify-gql/issues/211, but I'm not really sure if

1. this change is even correct
2. it's all that's necessary to comply with Fastify v3 changes