### PR TITLE
fix resolvers ts definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,10 +3,6 @@ import {
   FastifyReply,
   FastifyRequest,
   FastifyInstance,
-  RawServerBase,
-  RawRequestDefaultExpression,
-  RawReplyDefaultExpression,
-  FastifyPlugin,
 } from "fastify";
 import {
   DocumentNode,
@@ -67,7 +63,19 @@ interface QueryRequest {
   extensions?: object;
 }
 
-export interface FastifyGQLOptions {
+export interface FastifyGQLGatewayOptions {
+  /**
+   * A list of GraphQL services to be combined into the gateway schema
+   */
+  gateway: {
+    services: Array<{
+      name: string;
+      url: string;
+    }>;
+  };
+}
+
+export interface FastifyGQLSchemaOptions {
   /**
    * The GraphQL schema. String schema will be parsed
    */
@@ -75,7 +83,7 @@ export interface FastifyGQLOptions {
   /**
    * Object with resolver functions
    */
-  resolvers: IResolvers;
+  resolvers?: IResolvers;
   /**
    * Object with data loader functions
    */
@@ -92,6 +100,9 @@ export interface FastifyGQLOptions {
       ) => any;
     };
   };
+}
+
+export interface FastifyGQLCommonOptions {
   /**
    * Serve GraphiQL on /graphiql if true or 'graphiql', or GraphQL IDE on /playground if 'playground' and if routes is true
    */
@@ -172,15 +183,6 @@ export interface FastifyGQLOptions {
    */
   federationMetadata?: boolean;
   /**
-   * A list of GraphQL services to be combined into the gateway schema
-   */
-  gateway?: {
-    services: Array<{
-      name: string;
-      url: string;
-    }>;
-  };
-  /**
    * Persisted queries, overrides persistedQueryProvider.
    */
   persistedQueries?: object;
@@ -201,6 +203,7 @@ export interface FastifyGQLOptions {
   allowBatchedQueries?: boolean;
 }
 
+export type FastifyGQLOptions = FastifyGQLCommonOptions & (FastifyGQLGatewayOptions | FastifyGQLSchemaOptions)
 
 declare function fastifyGQL 
   (

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -3,6 +3,7 @@ import Fastify from 'fastify'
 import fastifyGQL, { FastifyGQLOptions } from '../..'
 // eslint-disable-next-line no-unused-vars
 import { ValidationContext, ValidationRule } from 'graphql'
+import { makeExecutableSchema } from 'graphql-tools'
 
 const app = Fastify()
 
@@ -124,3 +125,31 @@ makeGraphqlServer({ schema, resolvers })
 makeGraphqlServer({ schema, resolvers, validationRules: [] })
 makeGraphqlServer({ schema, resolvers, validationRules: [customValidationRule] })
 makeGraphqlServer({ schema, resolvers, validationRules: ({ variables, operationName, source }: { source: string, variables?: Record<string, any>, operationName?: string }) => [customValidationRule] })
+
+// Gateway mode
+
+const gateway = Fastify()
+
+gateway.register(fastifyGQL, {
+  gateway: {
+    services: [{
+      name: 'user',
+      url: 'http://localhost:4001/graphql'
+
+    }, {
+      name: 'post',
+      url: 'http://localhost:4002/graphql'
+    }]
+  }
+})
+
+// Executable schema
+
+const executableSchema = makeExecutableSchema({
+  typeDefs: [],
+  resolvers: []
+})
+
+gateway.register(fastifyGQL, {
+  schema: executableSchema
+})


### PR DESCRIPTION
[There is support for executableSchemas](https://github.com/mcollina/fastify-gql#makeexecutableschema-support), but the type definitions forces to define resolvers when it shouldn't.