### PR TITLE
Allow hasDirective to handle nodes that do not contain directives.

### DIFF
--- a/lib/gateway/service-map.js
+++ b/lib/gateway/service-map.js
@@ -11,7 +11,8 @@ const { buildRequest, sendRequest } = require('./request')
 const SubscriptionClient = require('../subscription-client')
 
 function hasDirective (directiveName, node) {
-  return node.directives.some(directive => directive.name.value === directiveName)
+  const { directives = [] } = node
+  return directives.some(directive => directive.name.value === directiveName)
 }
 
 function createFieldSet (definition, filterFn = () => false) {

--- a/test/gateway/schema.js
+++ b/test/gateway/schema.js
@@ -63,6 +63,8 @@ test('It builds the gateway schema correctly', async (t) => {
   }
 
   const userServicePort = await createService(t, `
+    directive @customDirective on FIELD_DEFINITION
+
     extend type Query {
       me: User
       hello: String
@@ -189,14 +191,14 @@ test('It builds the gateway schema correctly', async (t) => {
     }
     hello
   }
-  
+
   fragment UserFragment on User {
     id
     name
     avatar(size: medium)
     numberOfPosts
   }
-  
+
   fragment PostFragment on Post {
     pid
     title


### PR DESCRIPTION
### Summary

Currently if the SDL returned from the gateway's [`ServiceInfo`](https://github.com/mcollina/fastify-gql/blob/99a06a9ff480bc5aa8a6ab4b925b6d876f125645/lib/gateway/service-map.js#L67) query contains any directive definitions, the following error will be be thrown:
```js
TypeError: Cannot read property 'some' of undefined
```
This error originates from the [`hasDirective`](https://github.com/mcollina/fastify-gql/blob/99a06a9ff480bc5aa8a6ab4b925b6d876f125645/lib/gateway/service-map.js#L13) function, and is thrown because a [`DirectiveNode`](https://github.com/graphql/graphql-js/blob/6012d28b3b1fe8e002eefed9a3f013d4b352f08d/src/language/ast.js#L414) does not contain a `directives` field. 

Changes in this PR allow `hasDirective` to handle any [`ASTNode`](https://github.com/graphql/graphql-js/blob/6012d28b3b1fe8e002eefed9a3f013d4b352f08d/src/language/ast.js#L144) with a non-existent `directives` field.

### Test Plan
A custom directive has been added to the `userServicePort` schema in the schema test. Without the changes made to `hasDirective`, this test would fail (with the aforementioned error being thrown).

