### PR TITLE
Remove UniqueDirectivesPerLocationRule from validation for federated schemas

### DIFF
--- a/lib/federation.js
+++ b/lib/federation.js
@@ -34,6 +34,8 @@ const {
   isTypeExtensionNode,
   isObjectType
 } = require('graphql')
+const { validateSDL } = require('graphql/validation/validate')
+const compositionRules = require('./federation/compositionRules')
 
 const BASE_FEDERATION_TYPES = `
   scalar _Any
@@ -250,10 +252,25 @@ function buildFederationSchema (schema, isGateway) {
   })
 
   // Add all extensions
-  federationSchema = extendSchema(federationSchema, {
+  const extensionsDocument = {
     kind: Kind.DOCUMENT,
     definitions: extensions
-  })
+  }
+
+  // instead of relying on extendSchema internal validations
+  // we run validations in our code so that we can use slightly different rules
+  // as extendSchema internal rules are meant for regular usage
+  // and federated schemas have different constraints
+  const errors = validateSDL(extensionsDocument, federationSchema, compositionRules)
+  if (errors.length === 1) {
+    throw errors[0]
+  } else if (errors.length > 1) {
+    const err = new Error('Schema issues, check out the .errors property on the Error.')
+    err.errors = errors
+    throw err
+  }
+
+  federationSchema = extendSchema(federationSchema, extensionsDocument, { assumeValidSDL: true })
 
   if (!federationSchema.getType('Query')) {
     federationSchema = new GraphQLSchema({

--- a/lib/federation/compositionRules.js
+++ b/lib/federation/compositionRules.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { specifiedSDLRules } = require('graphql/validation/specifiedRules')
 const { UniqueDirectivesPerLocationRule } = require('graphql')
 

--- a/lib/federation/compositionRules.js
+++ b/lib/federation/compositionRules.js
@@ -1,0 +1,8 @@
+const { specifiedSDLRules } = require('graphql/validation/specifiedRules')
+const { UniqueDirectivesPerLocationRule } = require('graphql')
+
+// this rules overwrite the built-in rules for federation schema
+// here we only remove the UniqueDirectivesPerLocationRule from the standard rules
+// to fix https://github.com/mcollina/fastify-gql/issues/184
+// this is also the point were we may need to add federation-specific rules
+module.exports = specifiedSDLRules.filter(rule => rule !== UniqueDirectivesPerLocationRule)


### PR DESCRIPTION
This fixes https://github.com/mcollina/fastify-gql/issues/184

As discussed with @mcollina with this PR I'm going with the simplest fix just for the linked issue. 
We replicate Apollo's behaviour by moving validations in our code and skipping the `UniqueDirectivesPerLocationRule` rule.