### PR TITLE
Expose defaultErrorFormatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ package-lock.json
 
 # vscode
 .vscode/
+
+# intellij idea, webstorm
+.idea/

--- a/index.d.ts
+++ b/index.d.ts
@@ -184,7 +184,7 @@ export interface FastifyGQLCommonOptions {
     | {
         emitter?: object;
         verifyClient?: (
-          info: { origin: string; secure: boolean; req: IncomingMessage }, 
+          info: { origin: string; secure: boolean; req: IncomingMessage },
           next: (result: boolean, code?: number, message?: string, headers?: OutgoingHttpHeaders) => void
         ) => void,
         context?: (connection: SocketStream, request: FastifyRequest) => object | Promise<object>
@@ -217,7 +217,7 @@ export interface FastifyGQLCommonOptions {
 
 export type FastifyGQLOptions = FastifyGQLCommonOptions & (FastifyGQLGatewayOptions | FastifyGQLSchemaOptions)
 
-declare function fastifyGQL 
+declare function fastifyGQL
   (
     instance: FastifyInstance,
     opts: FastifyGQLOptions
@@ -276,6 +276,14 @@ declare namespace fastifyGQL {
     preparedOnly: (persistedQueries: object) => PeristedQueryProvider;
     automatic: (maxSize?: number) => PeristedQueryProvider;
   };
+
+  /**
+   * Default error formatter.
+   */
+  const defaultErrorFormatter: (
+    execution: ExecutionResult,
+    context: any
+  ) => { statusCode: number, response: ExecutionResult };
 }
 
 export default fastifyGQL;

--- a/index.js
+++ b/index.js
@@ -469,6 +469,7 @@ const plugin = fp(async function (app, opts) {
 })
 
 plugin.ErrorWithProps = ErrorWithProps
+plugin.defaultErrorFormatter = defaultErrorFormatter
 plugin.persistedQueryDefaults = persistedQueryDefaults
 
 module.exports = plugin

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -63,6 +63,11 @@ app.register(fastifyGQL, {
   cache: true
 })
 
+app.register(fastifyGQL, {
+  schema,
+  errorFormatter: fastifyGQL.defaultErrorFormatter,
+})
+
 app.register(async function (app) {
   app.graphql.extendSchema(`
     type Human {
@@ -134,6 +139,7 @@ makeGraphqlServer({ schema, resolvers })
 makeGraphqlServer({ schema, resolvers, validationRules: [] })
 makeGraphqlServer({ schema, resolvers, validationRules: [customValidationRule] })
 makeGraphqlServer({ schema, resolvers, validationRules: ({ variables, operationName, source }: { source: string, variables?: Record<string, any>, operationName?: string }) => [customValidationRule] })
+makeGraphqlServer({ schema, errorFormatter: fastifyGQL.defaultErrorFormatter })
 
 // Gateway mode
 

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -65,7 +65,7 @@ app.register(fastifyGQL, {
 
 app.register(fastifyGQL, {
   schema,
-  errorFormatter: fastifyGQL.defaultErrorFormatter,
+  errorFormatter: fastifyGQL.defaultErrorFormatter
 })
 
 app.register(async function (app) {


### PR DESCRIPTION
I would like to switch all thrown errors to 200, but preserve the built in error formatting capabilities by doing:

```
    errorFormatter: (err) => {
      err.statusCode = 200
      return defaultErrorFormatter(err)
    },
```