### PR TITLE
fix: extendSchema for federation

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,10 @@ const {
 } = require('graphql')
 const { buildExecutionContext } = require('graphql/execution/execute')
 const queryDepth = require('./lib/queryDepth')
-const buildFederationSchema = require('./lib/federation')
+const {
+  buildFederationSchema,
+  extendFederationSchema
+} = require('./lib/federation')
 const buildGateway = require('./lib/gateway')
 const mq = require('mqemitter')
 const { PubSub } = require('./lib/subscriber')
@@ -244,13 +247,17 @@ const plugin = fp(async function (app, opts) {
       throw new Error('Calling extendSchema method is not allowed when plugin is running in gateway mode is not allowed')
     }
 
-    if (typeof s === 'string') {
-      s = parse(s)
-    } else if (!s || typeof s !== 'object') {
-      throw new Error('Must provide valid Document AST')
-    }
+    if (opts.federationMetadata) {
+      fastifyGraphQl.schema = extendFederationSchema(fastifyGraphQl.schema, s)
+    } else {
+      if (typeof s === 'string') {
+        s = parse(s)
+      } else if (!s || typeof s !== 'object') {
+        throw new Error('Must provide valid Document AST')
+      }
 
-    fastifyGraphQl.schema = extendSchema(fastifyGraphQl.schema, s)
+      fastifyGraphQl.schema = extendSchema(fastifyGraphQl.schema, s)
+    }
   }
 
   fastifyGraphQl.defineResolvers = function (resolvers) {

--- a/index.js
+++ b/index.js
@@ -247,17 +247,14 @@ const plugin = fp(async function (app, opts) {
       throw new Error('Calling extendSchema method is not allowed when plugin is running in gateway mode is not allowed')
     }
 
-    if (opts.federationMetadata) {
-      fastifyGraphQl.schema = extendFederationSchema(fastifyGraphQl.schema, s)
-    } else {
-      if (typeof s === 'string') {
-        s = parse(s)
-      } else if (!s || typeof s !== 'object') {
-        throw new Error('Must provide valid Document AST')
-      }
-
-      fastifyGraphQl.schema = extendSchema(fastifyGraphQl.schema, s)
+    if (typeof s === 'string') {
+      s = parse(s)
+    } else if (!s || typeof s !== 'object') {
+      throw new Error('Must provide valid Document AST')
     }
+
+    fastifyGraphQl.schema = opts.federationMetadata
+      ? extendFederationSchema(fastifyGraphQl.schema, s) : extendSchema(fastifyGraphQl.schema, s)
   }
 
   fastifyGraphQl.defineResolvers = function (resolvers) {

--- a/lib/federation.js
+++ b/lib/federation.js
@@ -229,24 +229,24 @@ function addServiceResolver (schema, originalSchemaSDL) {
   return schema
 }
 
-function buildFederationSchema (schema, isGateway) {
-  let federationSchema = new GraphQLSchema({
-    query: undefined
+function extendFederationSchema (originalSchema, schema, isGateway) {
+  const parsedSchema = parse(schema)
+  const { typeStubs, extensions, definitions } = getStubTypes(parsedSchema.definitions, isGateway)
+
+  // Filter existing types (Query, Mutation, Subscriptions ...)
+  const stubs = typeStubs.filter(stub => {
+    return !originalSchema.getType(stub.name.value)
   })
 
-  federationSchema = extendSchema(federationSchema, parse(isGateway ? BASE_FEDERATION_TYPES : FEDERATION_SCHEMA))
-
-  const parsedOriginalSchema = parse(schema)
-  const { typeStubs, extensions, definitions } = getStubTypes(parsedOriginalSchema.definitions, isGateway)
-
-  // Add type stubs - only needed for federation
-  federationSchema = extendSchema(federationSchema, {
+  // Add type stubs
+  let extendedSchema = extendSchema(originalSchema, {
     kind: Kind.DOCUMENT,
-    definitions: typeStubs
+    definitions: stubs
+    // definitions: typeStubs
   })
 
   // Add default type definitions
-  federationSchema = extendSchema(federationSchema, {
+  extendedSchema = extendSchema(extendedSchema, {
     kind: Kind.DOCUMENT,
     definitions
   })
@@ -261,7 +261,7 @@ function buildFederationSchema (schema, isGateway) {
   // we run validations in our code so that we can use slightly different rules
   // as extendSchema internal rules are meant for regular usage
   // and federated schemas have different constraints
-  const errors = validateSDL(extensionsDocument, federationSchema, compositionRules)
+  const errors = validateSDL(extensionsDocument, extendedSchema, compositionRules)
   if (errors.length === 1) {
     throw errors[0]
   } else if (errors.length > 1) {
@@ -270,7 +270,18 @@ function buildFederationSchema (schema, isGateway) {
     throw err
   }
 
-  federationSchema = extendSchema(federationSchema, extensionsDocument, { assumeValidSDL: true })
+  extendedSchema = extendSchema(extendedSchema, extensionsDocument, { assumeValidSDL: true })
+
+  return extendedSchema
+}
+
+function buildFederationSchema (schema, isGateway) {
+  let federationSchema = new GraphQLSchema({
+    query: undefined
+  })
+
+  federationSchema = extendSchema(federationSchema, parse(isGateway ? BASE_FEDERATION_TYPES : FEDERATION_SCHEMA))
+  federationSchema = extendFederationSchema(federationSchema, schema, isGateway)
 
   if (!federationSchema.getType('Query')) {
     federationSchema = new GraphQLSchema({
@@ -295,4 +306,7 @@ function buildFederationSchema (schema, isGateway) {
   })
 }
 
-module.exports = buildFederationSchema
+module.exports = {
+  buildFederationSchema,
+  extendFederationSchema
+}

--- a/lib/federation.js
+++ b/lib/federation.js
@@ -230,8 +230,7 @@ function addServiceResolver (schema, originalSchemaSDL) {
 }
 
 function extendFederationSchema (originalSchema, schema, isGateway) {
-  const parsedSchema = parse(schema)
-  const { typeStubs, extensions, definitions } = getStubTypes(parsedSchema.definitions, isGateway)
+  const { typeStubs, extensions, definitions } = getStubTypes(schema.definitions, isGateway)
 
   // Filter existing types (Query, Mutation, Subscriptions ...)
   const stubs = typeStubs.filter(stub => {
@@ -281,7 +280,9 @@ function buildFederationSchema (schema, isGateway) {
   })
 
   federationSchema = extendSchema(federationSchema, parse(isGateway ? BASE_FEDERATION_TYPES : FEDERATION_SCHEMA))
-  federationSchema = extendFederationSchema(federationSchema, schema, isGateway)
+
+  const parsedSchema = parse(schema)
+  federationSchema = extendFederationSchema(federationSchema, parsedSchema, isGateway)
 
   if (!federationSchema.getType('Query')) {
     federationSchema = new GraphQLSchema({

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -6,7 +6,7 @@ const {
   isScalarType
 } = require('graphql')
 const { Factory } = require('single-user-cache')
-const buildFederatedSchema = require('./federation')
+const { buildFederationSchema } = require('./federation')
 const buildServiceMap = require('./gateway/service-map')
 const {
   makeResolver,
@@ -156,7 +156,7 @@ async function buildGateway (gatewayOpts, app) {
 
   const serviceSDLs = Object.values(serviceMap).map(service => service.schemaDefinition)
 
-  const schema = buildFederatedSchema(serviceSDLs.join(''), true)
+  const schema = buildFederationSchema(serviceSDLs.join(''), true)
 
   const typeToServiceMap = {}
   const typeFieldsToService = {}
@@ -329,7 +329,7 @@ async function buildGateway (gatewayOpts, app) {
         )
       )
 
-      const schema = buildFederatedSchema(_serviceSDLs, true)
+      const schema = buildFederationSchema(_serviceSDLs, true)
       defineResolvers(schema, typeToServiceMap, serviceMap, typeFieldsToService)
 
       return schema

--- a/test/gateway/pollingInterval.js
+++ b/test/gateway/pollingInterval.js
@@ -10,7 +10,7 @@ const immediate = promisify(setImmediate)
 
 const Fastify = require('fastify')
 const WebSocket = require('ws')
-const buildFederationSchema = require('../../lib/federation')
+const { buildFederationSchema } = require('../../lib/federation')
 const GQL = require('../..')
 
 test('Polling schemas', async (t) => {


### PR DESCRIPTION
This PR fixes an issue with `extendSchema` that wasn't working correctly with federated schema if we tried to extend the schema with an external type reference.