### PR TITLE
fix: handle gateway.service.wsConnectionParams

### DIFF
--- a/README.md
+++ b/README.md
@@ -900,6 +900,12 @@ __fastify-gql__ supports the following options:
     * `service.rewriteHeaders`: `Function` A function that gets the original headers as a parameter and returns an object containing values that should be added to the headers
     * `service.wsUrl`: The url of the websocket endpoint
     * `service.wsConnectionParams`: `Function` or `Object`
+      * `wsConnectionParams.connectionInitPayload`: `Function` or `Object` An object or a function that returns the `connection_init` payload sent to the service.
+      * `wsConnectionParams.reconnect`: `Boolean` Enable reconnect on connection close (Default: `false`)
+      * `wsConnectionParams.maxReconnectAttempts`: `Number` Defines the maximum reconnect attempts if reconnect is enabled (Default: `Infinity`)
+      * `wsConnectionParams.connectionCallback`: `Function` A function called after a `connection_ack` message is received.
+      * `wsConnectionParams.failedReconnectCallback`: `Function` A function called if reconnect is enabled and maxReconnectAttempts is reached.
+
 * `persistedQueries`: A hash/query map to resolve the full query text using it's unique hash. Overrides `persistedQueryProvider`.
 * `onlyPersisted`: Boolean. Flag to control whether to allow graphql queries other than persisted. When `true`, it'll make the server reject any queries that are not present in the `persistedQueries` option above. It will also disable any ide available (playground/graphiql). Requires `persistedQueries` to be set, and overrides `persistedQueryProvider`.
 * `persistedQueryProvider`

--- a/lib/gateway/service-map.js
+++ b/lib/gateway/service-map.js
@@ -50,6 +50,19 @@ function createTypeMap (schemaDefinition) {
   return { typeMap, types, extensionTypeMap }
 }
 
+async function getWsOpts (service) {
+  let opts = {
+    serviceName: service.name
+  }
+  if (typeof service.wsConnectionParams === 'object') {
+    opts = { ...opts, ...service.wsConnectionParams }
+  } else if (typeof service.wsConnectionParams === 'function') {
+    opts = { ...opts, ...(await service.wsConnectionParams()) }
+  }
+
+  return opts
+}
+
 async function buildServiceMap (services) {
   const serviceMap = {}
 
@@ -76,9 +89,8 @@ async function buildServiceMap (services) {
         if (serviceConfig.client) {
           serviceConfig.client.close()
 
-          const client = new SubscriptionClient(service.wsUrl, {
-            serviceName: service.name
-          })
+          const wsOpts = await getWsOpts(service)
+          const client = new SubscriptionClient(service.wsUrl, wsOpts)
 
           serviceConfig.client = client
           serviceConfig.createSubscription = client.createSubscription.bind(
@@ -121,9 +133,8 @@ async function buildServiceMap (services) {
     }
 
     if (service.wsUrl) {
-      const client = new SubscriptionClient(service.wsUrl, {
-        serviceName: service.name
-      })
+      const wsOpts = await getWsOpts(service)
+      const client = new SubscriptionClient(service.wsUrl, wsOpts)
 
       serviceConfig.client = client
       serviceConfig.createSubscription = client.createSubscription.bind(client)

--- a/lib/subscription-client.js
+++ b/lib/subscription-client.js
@@ -4,6 +4,7 @@ const WebSocket = require('ws')
 const {
   GQL_CONNECTION_INIT,
   GQL_CONNECTION_ACK,
+  GQL_CONNECTION_ERROR,
   GQL_START,
   GQL_DATA,
   GQL_COMPLETE,
@@ -26,7 +27,8 @@ class SubscriptionClient {
       maxReconnectAttempts = Infinity,
       serviceName,
       connectionCallback,
-      failedReconnectCallback
+      failedReconnectCallback,
+      connectionInitPayload
     } = config
 
     this.protocols = [GRAPHQL_WS, ...protocols]
@@ -36,6 +38,7 @@ class SubscriptionClient {
     this.reconnectAttempts = 0
     this.connectionCallback = connectionCallback
     this.failedReconnectCallback = failedReconnectCallback
+    this.connectionInitPayload = connectionInitPayload
 
     this.connect()
   }
@@ -46,7 +49,9 @@ class SubscriptionClient {
     this.socket.onopen = () => {
       /* istanbul ignore else */
       if (this.socket && this.socket.readyState === WebSocket.OPEN) {
-        this.sendMessage(null, GQL_CONNECTION_INIT)
+        const payload = typeof this.connectionInitPayload === 'function'
+          ? this.connectionInitPayload() : this.connectionInitPayload
+        this.sendMessage(null, GQL_CONNECTION_INIT, payload)
       }
     }
 
@@ -191,6 +196,9 @@ class SubscriptionClient {
           this.operations.delete(operationId)
         }
 
+        break
+      case GQL_CONNECTION_ERROR:
+        this.close(this.tryReconnect, false)
         break
       /* istanbul ignore next */
       default:

--- a/lib/subscription-client.js
+++ b/lib/subscription-client.js
@@ -49,9 +49,13 @@ class SubscriptionClient {
     this.socket.onopen = async () => {
       /* istanbul ignore else */
       if (this.socket && this.socket.readyState === WebSocket.OPEN) {
-        const payload = typeof this.connectionInitPayload === 'function'
-          ? await this.connectionInitPayload() : this.connectionInitPayload
-        this.sendMessage(null, GQL_CONNECTION_INIT, payload)
+        try {
+          const payload = typeof this.connectionInitPayload === 'function'
+            ? await this.connectionInitPayload() : this.connectionInitPayload
+          this.sendMessage(null, GQL_CONNECTION_INIT, payload)
+        } catch (err) {
+          this.close(this.tryReconnect, false)
+        }
       }
     }
 

--- a/lib/subscription-client.js
+++ b/lib/subscription-client.js
@@ -46,11 +46,11 @@ class SubscriptionClient {
   connect () {
     this.socket = new WebSocket(this.uri, this.protocols)
 
-    this.socket.onopen = () => {
+    this.socket.onopen = async () => {
       /* istanbul ignore else */
       if (this.socket && this.socket.readyState === WebSocket.OPEN) {
         const payload = typeof this.connectionInitPayload === 'function'
-          ? this.connectionInitPayload() : this.connectionInitPayload
+          ? await this.connectionInitPayload() : this.connectionInitPayload
         this.sendMessage(null, GQL_CONNECTION_INIT, payload)
       }
     }

--- a/test/gateway/subscription.js
+++ b/test/gateway/subscription.js
@@ -373,7 +373,7 @@ test('gateway wsConnectionParams function is passed to SubscriptionClient', t =>
           name: 'test',
           url: `http://localhost:${testServicePort}/graphql`,
           wsUrl: `ws://localhost:${testServicePort}/graphql`,
-          wsConnectionParams: function () {
+          wsConnectionParams: async function () {
             return {
               connectionInitPayload
             }

--- a/test/gateway/subscription.js
+++ b/test/gateway/subscription.js
@@ -181,7 +181,6 @@ test('gateway subscription handling works correctly', t => {
       messageService.close()
       userService.close()
       gateway.close()
-      process.exit(0)
     })
     client.setEncoding('utf8')
 
@@ -284,4 +283,104 @@ test('gateway subscription handling works correctly', t => {
   const startMessageService = createMessageService.bind(null, startGateway)
 
   createUserService(startMessageService)
+})
+
+test('gateway wsConnectionParams object is passed to SubscriptionClient', t => {
+  function onConnect (data) {
+    t.deepEqual(data.payload, connectionInitPayload)
+    t.end()
+  }
+
+  const connectionInitPayload = {
+    hello: 'world'
+  }
+  const testService = Fastify()
+  t.tearDown(() => {
+    testService.close()
+  })
+
+  testService.register(GQL, {
+    schema: `
+      type Query {
+        test: String
+      }
+    `,
+    federationMetadata: true,
+    subscription: { onConnect }
+  })
+
+  testService.listen(0, async err => {
+    t.error(err)
+    const testServicePort = testService.server.address().port
+
+    const gateway = Fastify()
+    t.tearDown(() => {
+      gateway.close()
+    })
+    gateway.register(GQL, {
+      subscription: true,
+      gateway: {
+        services: [{
+          name: 'test',
+          url: `http://localhost:${testServicePort}/graphql`,
+          wsUrl: `ws://localhost:${testServicePort}/graphql`,
+          wsConnectionParams: {
+            connectionInitPayload
+          }
+        }]
+      }
+    })
+    await gateway.ready()
+  })
+})
+
+test('gateway wsConnectionParams function is passed to SubscriptionClient', t => {
+  function onConnect (data) {
+    t.deepEqual(data.payload, connectionInitPayload)
+    t.end()
+  }
+
+  const connectionInitPayload = {
+    hello: 'world'
+  }
+  const testService = Fastify()
+  t.tearDown(() => {
+    testService.close()
+  })
+
+  testService.register(GQL, {
+    schema: `
+      type Query {
+        test: String
+      }
+    `,
+    federationMetadata: true,
+    subscription: { onConnect }
+  })
+
+  testService.listen(0, async err => {
+    t.error(err)
+    const testServicePort = testService.server.address().port
+
+    const gateway = Fastify()
+    t.tearDown(() => {
+      gateway.close()
+    })
+    gateway.register(GQL, {
+      subscription: true,
+      gateway: {
+        services: [{
+          name: 'test',
+          url: `http://localhost:${testServicePort}/graphql`,
+          wsUrl: `ws://localhost:${testServicePort}/graphql`,
+          wsConnectionParams: function () {
+            return {
+              connectionInitPayload
+            }
+          }
+        }]
+      }
+    })
+    await gateway.ready()
+  })
 })

--- a/test/subscription-client.js
+++ b/test/subscription-client.js
@@ -263,7 +263,7 @@ test('subscription client connectionInitPayload is correctly passed', (t) => {
   const client = new SubscriptionClient(`ws://localhost:${port}`, {
     reconnect: false,
     serviceName: 'test-service',
-    connectionInitPayload: function () {
+    connectionInitPayload: async function () {
       return connectionInitPayload
     }
   })

--- a/test/subscription-client.js
+++ b/test/subscription-client.js
@@ -268,3 +268,24 @@ test('subscription client connectionInitPayload is correctly passed', (t) => {
     }
   })
 })
+
+test('subscription client closes the connection if connectionInitPayload throws', (t) => {
+  const server = new WS.Server({ port: 0 })
+  const port = server.address().port
+
+  server.on('connection', function connection (ws) {
+    ws.on('close', function () {
+      client.close()
+      server.close()
+      t.end()
+    })
+  })
+
+  const client = new SubscriptionClient(`ws://localhost:${port}`, {
+    reconnect: false,
+    serviceName: 'test-service',
+    connectionInitPayload: async function () {
+      throw new Error('kaboom')
+    }
+  })
+})


### PR DESCRIPTION
This PR fixes the `gateway.service.wsConnectionParams` that is currently defined in the documentation but not handled.

It also adds the `connection_error` message handling for the `SubscriptionClient` and the `connectionInitPayload` option.