### PR TITLE
Support variables inside nested arguments in gateway resolver

### DIFF
--- a/lib/gateway/make-resolver.js
+++ b/lib/gateway/make-resolver.js
@@ -215,6 +215,16 @@ function createFieldResolverOperation ({ parentType, fieldName, selections, vari
   })
 }
 
+function collectVariableNames (acc, fields) {
+  for (const field of fields) {
+    if (field.value.kind === Kind.VARIABLE) {
+      acc.push(field.value.name.value)
+    } else if (field.value.kind === Kind.OBJECT) {
+      collectVariableNames(acc, field.value.fields);
+    }
+  }
+}
+
 function collectArgumentNames (fieldNode) {
   const argumentNames = []
 
@@ -222,7 +232,11 @@ function collectArgumentNames (fieldNode) {
     for (const argument of fieldNode.arguments) {
       /* istanbul ignore else if there is no arguments property we return empty array */
       if (argument.value.kind === Kind.VARIABLE) {
-        argumentNames.push(argument.name.value)
+        argumentNames.push(argument.value.name.value)
+      } else if (argument.value.kind === Kind.OBJECT) {
+        collectVariableNames(argumentNames, argument.value.fields)
+      } else if (argument.value.kind === Kind.LIST) {
+        // TODO: Support GraphQL List
       }
     }
   }

--- a/lib/gateway/make-resolver.js
+++ b/lib/gateway/make-resolver.js
@@ -220,7 +220,7 @@ function collectVariableNames (acc, fields) {
     if (field.value.kind === Kind.VARIABLE) {
       acc.push(field.value.name.value)
     } else if (field.value.kind === Kind.OBJECT) {
-      collectVariableNames(acc, field.value.fields);
+      collectVariableNames(acc, field.value.fields)
     }
   }
 }


### PR DESCRIPTION
This PR fixes the following use cases with fastify-gql gateway.

## Case 1: Variables name doesn't match argument name

```graphql
mutation createTeam1($input1: CreateTeamInput!) {
  createTeam(input: $input1){
    team{
      name
    }
  }
}
```

```
{
  "input1": {
    "team": {
      "adminPersonId": "f18b72b0-e8f8-11ea-adc1-0242ac120002"
    }
  }
}
```

## Case 2 : Nested variables

```graphql
mutation createTeam2($team: TeamInput!) {
  createTeam(input: {
    team: $team
  }){
    team{
      name
    }
  }
}
```

```
{
 "team": {
    "adminPersonId": "f18b72b0-e8f8-11ea-adc1-0242ac120002"
  }
}
```